### PR TITLE
Fix macroquad link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ Work in progress, right now only jsons deserialization is implemented.
 And this is going to be even more restricted and limited serialization/deserialization library than makepad-tinyserde. 
 Generic bounds, lifetime bounds, where clauses and probably a lot more is not supported and probably will never be supported.
 
-This is used in [macroquad](github.com/not-fl3/macroquad/) game engine and only features needed for macroquad's internal serialization needs are going to be well supported. 
+This is used in [macroquad](https://github.com/not-fl3/macroquad/) game engine and only features needed for macroquad's internal serialization needs are going to be well supported. 
 


### PR DESCRIPTION
The current URL is interpreted as relative.