### PR TITLE
Improve crates.io page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Fork of makepad-tinyserde without any external dependencies."
 edition = "2018"
+repository = "https://github.com/not-fl3/nanoserde"
 
 [dependencies]
 nanoserde-derive = { path = "derive", version = "=0.1.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "Fork of makepad-tinyserde without any external dependencies."
 edition = "2018"
 repository = "https://github.com/not-fl3/nanoserde"
+readme = "README.md"
 
 [dependencies]
 nanoserde-derive = { path = "derive", version = "=0.1.9" }


### PR DESCRIPTION
https://crates.io/crates/nanoserde is missing a github link and the readme right now