### PR TITLE
Support exponent in JSON number & add implement std::error::Error trait

### DIFF
--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -421,13 +421,30 @@ impl DeJsonState {
                     self.numbuf.push(self.cur);
                     self.next(i);
                 }
+                let mut is_float = false;
                 if self.cur == '.' {
+                    is_float = true;
                     self.numbuf.push(self.cur);
                     self.next(i);
                     while self.cur >= '0' && self.cur <= '9' {
                         self.numbuf.push(self.cur);
                         self.next(i);
                     }
+                }
+                if self.cur == 'e' || self.cur == 'E' {
+                    is_float = true;
+                    self.numbuf.push(self.cur);
+                    self.next(i);
+                    if self.cur == '-' {
+                        self.numbuf.push(self.cur);
+                        self.next(i);
+                    }
+                    while self.cur >= '0' && self.cur <= '9' {
+                        self.numbuf.push(self.cur);
+                        self.next(i);
+                    }
+                }
+                if is_float {
                     if let Ok(num) = self.numbuf.parse() {
                         self.tok = DeJsonTok::F64(num);
                         return Ok(());

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -254,3 +254,40 @@ fn hashmaps() {
     assert_eq!(foo.map["asd"], 1);
     assert_eq!(foo.map["qwe"], 2);
 }
+
+#[test]
+fn exponents(){
+    #[derive(DeJson)]
+    struct Foo {
+        a: f64,
+        b: f64,
+        c: f64,
+        d: f64,
+        e: f64,
+        f: f64,
+        g: f64,
+        h: f64,
+    };
+
+    let json = r#"{
+        "a": 1e2,
+        "b": 1e-2,
+        "c": 1E2,
+        "d": 1E-2,
+        "e": 1.0e2,
+        "f": 1.0e-2,
+        "g": 1.0E2,
+        "h": 1.0E-2
+    }"#;
+
+    let foo: Foo = DeJson::deserialize_json(json).unwrap();
+
+    assert_eq!(foo.a, 100.);
+    assert_eq!(foo.b, 0.01);
+    assert_eq!(foo.c, 100.);
+    assert_eq!(foo.d, 0.01);
+    assert_eq!(foo.e, 100.);
+    assert_eq!(foo.f, 0.01);
+    assert_eq!(foo.g, 100.);
+    assert_eq!(foo.h, 0.01);
+}


### PR DESCRIPTION
Thins I noticed while making a glTF parser.

Two changes in one :
* Support exponent in JSON numbers (e.g. 1e2 == 100). Always floating point. Available in branch json_exponents.
* Implement std::error::Error trait for DeJsonErr. Includes Display trait that is the same as Debug. Might make sense to add to other error types as well but this one was annoying me right now. Available in branch std_error.

Putting both changes in one PR because they both add a test which generates a merge conflict.