### PR TITLE
Implement Clone on error types

### DIFF
--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -19,6 +19,7 @@ pub trait DeBin: Sized {
     fn de_bin(o: &mut usize, d: &[u8]) -> Result<Self, DeBinErr>;
 }
 
+#[derive(Clone)]
 pub struct DeBinErr {
     pub o: usize,
     pub l: usize,

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -100,6 +100,7 @@ pub struct DeJsonState {
     pub col: usize,
 }
 
+#[derive(Clone)]
 pub struct DeJsonErr {
     pub msg: String,
     pub line: usize,

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -93,6 +93,7 @@ pub struct DeRonState {
     pub col: usize,
 }
 
+#[derive(Clone)]
 pub struct DeRonErr {
     pub msg: String,
     pub line: usize,

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -35,6 +35,7 @@ pub enum Toml {
     Array(Vec<Toml>),
 }
 
+#[derive(Clone)]
 pub struct TomlErr {
     pub msg: String,
     pub line: usize,


### PR DESCRIPTION
Hello, thanks for your work on nanoserde,

why
---

Using nanoserde in a personal project I faced the issue that the error types are not clonable.
I can temporary solve that issue on my end using Arc, but it would be simpler to just clone the errors when needed.

what
-----

This PR derives Clone on all of nanoserde's error types.