### PR TITLE
Add Error implementations

### DIFF
--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -36,6 +36,14 @@ impl std::fmt::Debug for DeBinErr {
     }
 }
 
+impl std::fmt::Display for DeBinErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for DeBinErr {}
+
 macro_rules! impl_ser_de_bin_for {
     ($ty:ident) => {
         impl SerBin for $ty {

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -112,6 +112,14 @@ impl std::fmt::Debug for DeRonErr {
     }
 }
 
+impl std::fmt::Display for DeRonErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for DeRonErr {}
+
 impl DeRonState {
     pub fn next(&mut self, i: &mut Chars) {
         if let Some(c) = i.next() {

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -54,6 +54,14 @@ impl std::fmt::Debug for TomlErr {
     }
 }
 
+impl std::fmt::Display for TomlErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for TomlErr {}
+
 impl TomlParser {
     pub fn to_val(&mut self, tok: TomlTok, i: &mut Chars) -> Result<Toml, TomlErr> {
         match tok {


### PR DESCRIPTION
`Error` is already implemented for Json, no reason not to have it for the others.