### PR TITLE
Add RON Serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 /target
 Cargo.lock
-.envrc
-nix/
-shell.nix

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 Cargo.lock
+.envrc
+nix/
+shell.nix

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ For more examples take a look on [tests](/tests)
 | field: `i*`/`f*`/`String`/`T: De*/Ser*`        | yes    | yes   | yes    | no    |
 | field attribute: `#[nserde(default)]`          | yes    | no    | yes    | no    |
 | field attribute: `#[nserde(rename = "")]`      | yes    | yes   | yes    | no    |
-| field attribute: `#[nserde(proxy = "")]`       | no     | yes   | yes    | no    |
+| field attribute: `#[nserde(proxy = "")]`       | no     | yes   | no     | no    |
 | container attribute: `#[nserde(default)]`      | yes    | no    | yes    | no    |
 | container attribute: `#[nserde(rename = "")]`  | yes    | yes   | yes    | no    |
-| container attribute: `#[nserde(proxy = "")]`   | yes    | yes   | yes    | no    |
+| container attribute: `#[nserde(proxy = "")]`   | yes    | yes   | no     | no    |
 

--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ For more examples take a look on [tests](/tests)
 
 | Feature                                        | json   | bin   | ron    | toml  |
 | ---------------------------------------------- | ------ | ----- | ------ | ----- |
-| serialization                                  | yes    | yes   | no     | no    |
+| serialization                                  | yes    | yes   | yes    | no    |
 | deserialization                                | yes    | yes   | yes    | no    |
 | container: Struct                              | yes    | yes   | yes    | no    |
-| container: Tuple Struct                        | no     | yes   | no     | no    |
-| container: Enum                                | yes    | yes   | no     | no    |
+| container: Tuple Struct                        | no     | yes   | yes    | no    |
+| container: Enum                                | yes    | yes   | yes    | no    |
 | field: `std::collections::HashMap`             | yes    | yes   | yes    | no    |
 | field: `std::vec::Vec`                         | yes    | yes   | yes    | no    |
 | field: `Option`                                | yes    | yes   | yes    | no    |
 | field: `i*`/`f*`/`String`/`T: De*/Ser*`        | yes    | yes   | yes    | no    |
 | field attribute: `#[nserde(default)]`          | yes    | no    | yes    | no    |
 | field attribute: `#[nserde(rename = "")]`      | yes    | yes   | yes    | no    |
-| field attribute: `#[nserde(proxy = "")]`       | no     | yes   | no     | no    |
+| field attribute: `#[nserde(proxy = "")]`       | no     | yes   | yes    | no    |
 | container attribute: `#[nserde(default)]`      | yes    | no    | yes    | no    |
 | container attribute: `#[nserde(rename = "")]`  | yes    | yes   | yes    | no    |
-| container attribute: `#[nserde(proxy = "")]`   | yes    | yes   | no     | no    |
+| container attribute: `#[nserde(proxy = "")]`   | yes    | yes   | yes    | no    |
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -28,7 +28,7 @@ pub fn derive_ser_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream
         parse::Data::Struct(struct_) if struct_.named => derive_ser_bin_struct(struct_),
         parse::Data::Struct(struct_) => derive_ser_bin_struct_unnamed(struct_),
         parse::Data::Enum(enum_) => derive_ser_bin_enum(enum_),
-        _ => unimplemented!("Only structs are supported"),
+        _ => unimplemented!("Only structs and enums are supported"),
     };
 
     ts
@@ -48,31 +48,29 @@ pub fn derive_de_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
         parse::Data::Struct(struct_) => derive_de_bin_struct_unnamed(struct_),
         parse::Data::Enum(enum_) => derive_de_bin_enum(enum_),
 
-        _ => unimplemented!("Only structs are supported"),
+        _ => unimplemented!("Only structs and enums are supported"),
     };
 
     ts
 }
 
 #[proc_macro_derive(SerRon, attributes(nserde))]
-pub fn derive_ser_ron(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    // let input = parse_macro_input!(input as DeriveInput);
-    // // ok we have an ident, its either a struct or a enum
-    // let ts = match &input.data {
-    //     Data::Struct(DataStruct {fields: Fields::Named(fields), ..}) => {
-    //         derive_ser_ron_struct(&input, fields)
-    //     },
-    //     Data::Struct(DataStruct {fields: Fields::Unnamed(fields), ..}) => {
-    //         derive_ser_ron_struct_unnamed(&input, fields)
-    //     },
-    //     Data::Enum(enumeration) => {
-    //         derive_ser_ron_enum(&input, enumeration)
-    //     },
-    //     _ => error(Span::call_site(), "only structs or enums supported")
-    // };
-    // proc_macro::TokenStream::from(ts)
+pub fn derive_ser_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse::parse_data(input);
 
-    unimplemented!()
+    if let Some(proxy) = shared::attrs_proxy(&input.attributes()) {
+        return derive_ser_ron_proxy(&proxy, &input.name());
+    }
+
+    // ok we have an ident, its either a struct or a enum
+    let ts = match &input {
+        parse::Data::Struct(struct_) if struct_.named => derive_ser_ron_struct(struct_),
+        parse::Data::Struct(struct_) => derive_ser_ron_struct_unnamed(struct_),
+        parse::Data::Enum(enum_) => derive_ser_ron_enum(enum_),
+        _ => unimplemented!("Only structs and enums are supported"),
+    };
+
+    ts
 }
 
 #[proc_macro_derive(DeRon, attributes(nserde))]
@@ -85,8 +83,10 @@ pub fn derive_de_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 
     // ok we have an ident, its either a struct or a enum
     let ts = match &input {
-        parse::Data::Struct(struct_) => derive_de_ron_struct(struct_),
-        _ => unimplemented!("Only structs are supported"),
+        parse::Data::Struct(struct_) if struct_.named => derive_de_ron_struct(struct_),
+        parse::Data::Struct(struct_) => derive_de_ron_struct_unnamed(struct_),
+        parse::Data::Enum(enum_) => derive_de_ron_enum(enum_),
+        _ => unimplemented!("Only structs and enums are supported"),
     };
 
     ts

--- a/derive/src/serde_ron.rs
+++ b/derive/src/serde_ron.rs
@@ -7,9 +7,9 @@ use crate::shared;
 pub fn derive_ser_ron_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
         "impl SerRon for {} {{
-            fn ser_ron(&self, s: &mut Vec<u8>) {{
+            fn ser_ron(&self, d: usize, s: &mut nanoserde::SerRonState) {{
                 let proxy: {} = self.into();
-                proxy.ser_ron(s);
+                proxy.ser_ron(d, s);
             }}
         }}",
         type_, proxy_type
@@ -21,7 +21,7 @@ pub fn derive_ser_ron_proxy(proxy_type: &str, type_: &str) -> TokenStream {
 pub fn derive_de_ron_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
         "impl DeRon for {} {{
-            fn de_ron(_s: &mut nanoserde::DeJsonState, i: &mut std::str::Chars) -> std::result::Result<Self, nanoserde::DeJsonErr> {{
+            fn de_ron(_s: &mut nanoserde::DeRonState, i: &mut std::str::Chars) -> std::result::Result<Self, nanoserde::DeRonErr> {{
                 let proxy: {} = DeRon::deserialize_ron(i)?;
                 std::result::Result::Ok(Into::into(&proxy))
             }}
@@ -261,7 +261,7 @@ pub fn derive_ser_ron_enum(enum_: &Enum) -> TokenStream {
         let ident = &variant.name;
         // Unit
         if variant.fields.len() == 0 {
-            l!(body, "Self::{} => s.out.push_str({}),", ident, ident)
+            l!(body, "Self::{} => s.out.push_str(\"{}\"),", ident, ident)
         }
         // Named
         else if variant.named {

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -417,12 +417,13 @@ impl DeJsonState {
                 self.tok = DeJsonTok::CurlyClose;
                 return Ok(());
             }
-            '-' | '0'..='9' => {
+            '-' | '+' | '0'..='9' => {
                 self.numbuf.truncate(0);
-                let is_neg = if self.cur == '-' {
+                let is_neg = if self.cur == '-' || self.cur == '+' {
+                    let sign = self.cur;
                     self.numbuf.push(self.cur);
                     self.next(i);
-                    true
+                    sign == '-'
                 } else {
                     false
                 };

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -444,12 +444,13 @@ impl DeRonState {
                         return Err(self.err_parse("comment"));
                     }
                 }
-                '-' | '0'..='9' => {
+                '.' | '-' | '+' | '0'..='9' => {
                     self.numbuf.truncate(0);
-                    let is_neg = if self.cur == '-' {
+                    let is_neg = if self.cur == '-' || self.cur == '+' {
+                        let sign = self.cur;
                         self.numbuf.push(self.cur);
                         self.next(i);
-                        true
+                        sign == '-'
                     } else {
                         false
                     };
@@ -457,13 +458,30 @@ impl DeRonState {
                         self.numbuf.push(self.cur);
                         self.next(i);
                     }
+                    let mut is_float = false;
                     if self.cur == '.' {
+                        is_float = true;
                         self.numbuf.push(self.cur);
                         self.next(i);
                         while self.cur >= '0' && self.cur <= '9' {
                             self.numbuf.push(self.cur);
                             self.next(i);
                         }
+                    }
+                    if self.cur == 'e' || self.cur == 'E' {
+                        is_float = true;
+                        self.numbuf.push(self.cur);
+                        self.next(i);
+                        if self.cur == '-' {
+                            self.numbuf.push(self.cur);
+                            self.next(i);
+                        }
+                        while self.cur >= '0' && self.cur <= '9' {
+                            self.numbuf.push(self.cur);
+                            self.next(i);
+                        }
+                    }
+                    if is_float {
                         if let Ok(num) = self.numbuf.parse() {
                             self.tok = DeRonTok::F64(num);
                             return Ok(());
@@ -492,6 +510,7 @@ impl DeRonState {
                     while self.cur >= 'a' && self.cur <= 'z'
                         || self.cur >= 'A' && self.cur <= 'Z'
                         || self.cur == '_'
+                        || self.cur >= '0' && self.cur <= '9'
                     {
                         self.identbuf.push(self.cur);
                         self.next(i);
@@ -530,9 +549,19 @@ impl DeRonState {
                                 'n' => self.strbuf.push('\n'),
                                 'r' => self.strbuf.push('\r'),
                                 't' => self.strbuf.push('\t'),
+                                'b' => self.strbuf.push('\x08'),
+                                'f' => self.strbuf.push('\x0c'),
                                 '0' => self.strbuf.push('\0'),
                                 '\0' => {
                                     return Err(self.err_parse("string"));
+                                }
+                                'u' => {
+                                    if let Some(c) = self.hex_unescape_char(i) {
+                                        self.strbuf.push(c);
+                                        continue;
+                                    } else {
+                                        return Err(self.err_parse("string"));
+                                    }
                                 }
                                 _ => self.strbuf.push(self.cur),
                             }
@@ -553,6 +582,61 @@ impl DeRonState {
                     return Err(self.err_token("tokenizer"));
                 }
             }
+        }
+    }
+
+    /// Helper for reading `\uXXXX` escapes out of a string, properly handing
+    /// surrogate pairs (by potentially unescaping a second `\uXXXX` sequence if
+    /// it would complete a surrogate pair).
+    ///
+    /// On illegal escapes or unpaired surrogates returns None (and caller
+    /// should emit an error).
+    fn hex_unescape_char(&mut self, i: &mut Chars) -> Option<char> {
+        self.next(i);
+        let a = xdigit4(self, i)?;
+        if let Some(c) = core::char::from_u32(a as u32) {
+            return Some(c);
+        }
+        // `a` isn't a valid scalar, but if it's leading surrogate, we look for
+        // a trailing surrogate in a `\uXXXX` sequence immediately after.
+        let a_is_lead = (0xd800..0xdc00).contains(&a);
+        if a_is_lead && self.cur == '\\' {
+            self.next(i);
+            if self.cur == 'u' {
+                self.next(i);
+                let b = xdigit4(self, i)?;
+                let b_is_trail = (0xdc00..0xe000).contains(&b);
+                if b_is_trail {
+                    // It's a valid pair! We have `[a, b]` where `a` is a leading
+                    // surrogate and `b` is a trailing one.
+                    let scalar = (((a as u32 - 0xd800) << 10) | (b as u32 - 0xdc00)) + 0x10000;
+                    // All valid surrogate pairs decode to unicode scalar values
+                    // (e.g. `char`), so this block should always return `Some`, the
+                    // debug_assert exists just to ensure our testing is thorough
+                    // enough.
+                    let ch = core::char::from_u32(scalar);
+                    debug_assert!(ch.is_some());
+                    return ch;
+                }
+            }
+        }
+        return None;
+
+        // Helper to turn next 4 ascii hex digits into a u16
+        fn xdigit4(de: &mut DeRonState, i: &mut Chars) -> Option<u16> {
+            // as tempting as it is to try to find a way to use from_str_radix on the
+            // next 4 bytes from `i`, we'd still need to do validation to detect cases
+            // like `\u+123` and such which makes it less attractive.
+            (0..4).try_fold(0u16, |acc, _| {
+                let n = match de.cur {
+                    '0'..='9' => (de.cur as u16 - '0' as u16),
+                    'a'..='f' => (de.cur as u16 - 'a' as u16) + 10,
+                    'A'..='F' => (de.cur as u16 - 'A' as u16) + 10,
+                    _ => return None,
+                };
+                de.next(i);
+                Some(acc * 16 + n)
+            })
         }
     }
 }

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -1,4 +1,4 @@
-use nanoserde::DeRon;
+use nanoserde::{DeRon, SerRon};
 
 #[test]
 fn ron_de() {
@@ -6,6 +6,7 @@ fn ron_de() {
     pub struct Test {
         a: i32,
         b: f32,
+        c: Option<String>,
         d: Option<String>,
     }
 
@@ -18,5 +19,362 @@ fn ron_de() {
     let test: Test = DeRon::deserialize_ron(ron).unwrap();
     assert_eq!(test.a, 1);
     assert_eq!(test.b, 2.);
+    assert_eq!(test.c, None);
     assert_eq!(test.d.unwrap(), "hello");
+}
+
+#[test]
+fn de_container_default() {
+    #[derive(DeRon)]
+    #[nserde(default)]
+    pub struct Test {
+        pub a: i32,
+        pub b: f32,
+        c: Option<String>,
+        d: Option<String>,
+    }
+
+    let ron = r#"(
+        a: 1,
+        d: "hello",
+    )"#;
+
+    let test: Test = DeRon::deserialize_ron(ron).unwrap();
+    assert_eq!(test.a, 1);
+    assert_eq!(test.b, 0.);
+    assert_eq!(test.d.unwrap(), "hello");
+    assert_eq!(test.c, None);
+}
+
+#[test]
+fn rename() {
+    #[derive(DeRon, SerRon, PartialEq)]
+    #[nserde(default)]
+    pub struct Test {
+        #[nserde(rename = "fooField")]
+        pub a: i32,
+        #[nserde(rename = "barField")]
+        pub b: i32,
+    }
+
+    let ron = r#"(
+        fooField: 1,
+        barField: 2,
+    )"#;
+
+    let test: Test = DeRon::deserialize_ron(ron).unwrap();
+    assert_eq!(test.a, 1);
+    assert_eq!(test.b, 2);
+
+    let bytes = SerRon::serialize_ron(&test);
+    let test_deserialized = DeRon::deserialize_ron(&bytes).unwrap();
+    assert!(test == test_deserialized);
+}
+
+#[test]
+fn de_field_default() {
+    #[derive(DeRon)]
+    struct Foo {
+        x: i32,
+    }
+    impl Default for Foo {
+        fn default() -> Foo {
+            Foo { x: 23 }
+        }
+    }
+
+    #[derive(DeRon)]
+    pub struct Test {
+        a: i32,
+        #[nserde(default)]
+        foo: Foo,
+        foo2: Foo,
+        b: f32,
+    }
+
+    let ron = r#"(
+        a: 1,
+        b: 2.,
+        foo2: (x: 3)
+    )"#;
+
+    let test: Test = DeRon::deserialize_ron(ron).unwrap();
+    assert_eq!(test.a, 1);
+    assert_eq!(test.b, 2.);
+    assert_eq!(test.foo.x, 23);
+    assert_eq!(test.foo2.x, 3);
+}
+
+#[test]
+fn doctests() {
+    /// This is test
+    /// second doc comment
+    #[derive(DeRon)]
+    pub struct Test {
+        /// with documented field
+        pub a: i32,
+        pub b: f32,
+        /// or here
+        /// Or here
+        c: Option<String>,
+        /// more doc comments
+        /// and more
+        d: Option<String>,
+    }
+
+    let ron = r#"(
+        a: 1,
+        b: 2.0,
+        d: "hello"
+    )"#;
+
+    let test: Test = DeRon::deserialize_ron(ron).unwrap();
+    assert_eq!(test.a, 1);
+    assert_eq!(test.b, 2.);
+    assert_eq!(test.d.unwrap(), "hello");
+    assert_eq!(test.c, None);
+}
+
+#[test]
+fn empty() {
+    #[derive(DeRon)]
+    pub struct Empty {}
+
+    let ron = r#"(
+    )"#;
+
+    let _: Empty = DeRon::deserialize_ron(ron).unwrap();
+}
+
+#[test]
+fn one_field() {
+    #[derive(DeRon, SerRon, PartialEq)]
+    pub struct OneField {
+        field: f32,
+    }
+
+    let test = OneField { field: 23. };
+    let bytes = SerRon::serialize_ron(&test);
+    let test_deserialized = DeRon::deserialize_ron(&bytes).unwrap();
+    assert!(test == test_deserialized);
+}
+
+#[test]
+fn one_field_map() {
+    #[derive(DeRon, SerRon, PartialEq)]
+    pub struct OneField {
+        field: std::collections::HashMap<String, f32>,
+    }
+
+    let test = OneField {
+        field: std::collections::HashMap::new(),
+    };
+    let bytes = SerRon::serialize_ron(&test);
+    let test_deserialized = DeRon::deserialize_ron(&bytes).unwrap();
+    assert!(test == test_deserialized);
+}
+
+#[test]
+fn array() {
+    #[derive(DeRon)]
+    pub struct Foo {
+        x: i32,
+    }
+
+    #[derive(DeRon)]
+    pub struct Bar {
+        foos: Vec<Foo>,
+        ints: Vec<i32>,
+        floats_a: Option<Vec<f32>>,
+        floats_b: Option<Vec<f32>>,
+    }
+
+    let ron = r#"(
+       foos: [(x: 1), (x: 2)],
+       ints: [1, 2, 3, 4],
+       floats_b: [4., 3., 2., 1.]
+    )"#;
+
+    let bar: Bar = DeRon::deserialize_ron(ron).unwrap();
+
+    assert_eq!(bar.foos.len(), 2);
+    assert_eq!(bar.foos[0].x, 1);
+    assert_eq!(bar.ints.len(), 4);
+    assert_eq!(bar.ints[2], 3);
+    assert_eq!(bar.floats_b.unwrap()[2], 2.);
+    assert_eq!(bar.floats_a, None);
+}
+
+#[test]
+fn path_type() {
+    #[derive(DeRon)]
+    struct Foo {
+        a: i32,
+        b: std::primitive::i32,
+        c: Option<std::primitive::i32>,
+        d: Option<Vec<std::vec::Vec<std::primitive::i32>>>,
+    }
+
+    let ron = r#"(
+       a: 0,
+       b: 1,
+       c: 2,
+       d: [[1, 2], [3, 4]]
+    )"#;
+
+    let bar: Foo = DeRon::deserialize_ron(ron).unwrap();
+
+    assert_eq!(bar.a, 0);
+    assert_eq!(bar.b, 1);
+    assert_eq!(bar.c, Some(2));
+    assert_eq!(bar.d, Some(vec![vec![1, 2], vec![3, 4]]));
+}
+
+#[test]
+fn hashmaps() {
+    #[derive(DeRon)]
+    struct Foo {
+        map: std::collections::HashMap<String, i32>,
+    }
+
+    let ron = r#"(
+       map: {
+          "asd": 1,
+          "qwe": 2,
+       }
+    )"#;
+
+    let foo: Foo = DeRon::deserialize_ron(ron).unwrap();
+
+    assert_eq!(foo.map["asd"], 1);
+    assert_eq!(foo.map["qwe"], 2);
+}
+
+#[test]
+fn exponents() {
+    #[derive(DeRon)]
+    struct Foo {
+        a: f64,
+        b: f64,
+        c: f64,
+        d: f64,
+        e: f64,
+        f: f64,
+        g: f64,
+        h: f64,
+    };
+
+    let ron = r#"(
+        a: 1e2,
+        b: 1e-2,
+        c: 1E2,
+        d: 1E-2,
+        e: 1.0e2,
+        f: 1.0e-2,
+        g: 1.0E2,
+        h: 1.0E-2
+    )"#;
+
+    let foo: Foo = DeRon::deserialize_ron(ron).unwrap();
+
+    assert_eq!(foo.a, 100.);
+    assert_eq!(foo.b, 0.01);
+    assert_eq!(foo.c, 100.);
+    assert_eq!(foo.d, 0.01);
+    assert_eq!(foo.e, 100.);
+    assert_eq!(foo.f, 0.01);
+    assert_eq!(foo.g, 100.);
+    assert_eq!(foo.h, 0.01);
+}
+
+#[test]
+fn ronerror() {
+    #[derive(DeRon)]
+    #[allow(dead_code)]
+    struct Foo {
+        i: i32,
+    }
+
+    let ron = r#"(
+       i: "string"
+    )"#;
+
+    let res: Result<Foo, _> = DeRon::deserialize_ron(ron);
+    match res {
+        Ok(_) => assert!(false),
+        Err(e) => {
+            let _dyn_e: Box<dyn std::error::Error> = std::convert::From::from(e);
+        }
+    }
+}
+
+#[test]
+fn de_enum() {
+    #[derive(DeRon, PartialEq, Debug)]
+    pub enum Foo {
+        A,
+        B(i32, String),
+        C { a: i32, b: String },
+    }
+
+    #[derive(DeRon, PartialEq, Debug)]
+    pub struct Bar {
+        foo1: Foo,
+        foo2: Foo,
+        foo3: Foo,
+    }
+
+    let ron = r#"
+       (
+          foo1: A,
+          foo2: B(1, "asd"),
+          foo3: C(a: 2, b: "qwe"),
+       )
+    "#;
+
+    let test: Bar = DeRon::deserialize_ron(ron).unwrap();
+
+    assert_eq!(test.foo1, Foo::A);
+    assert_eq!(test.foo2, Foo::B(1, "asd".to_string()));
+    assert_eq!(
+        test.foo3,
+        Foo::C {
+            a: 2,
+            b: "qwe".to_string()
+        }
+    );
+}
+
+#[test]
+fn test_various_escapes() {
+    let ron = r#""\n\t\u0020\f\b\\\"\/\ud83d\uDE0B\r""#;
+    let unescaped: String = DeRon::deserialize_ron(ron).unwrap();
+    assert_eq!(unescaped, "\n\t\u{20}\x0c\x08\\\"/😋\r");
+}
+
+// there are only 1024*1024 surrogate pairs, so we can do an exhautive test.
+#[test]
+fn test_surrogate_pairs_exhaustively() {
+    for lead in 0xd800..0xdc00 {
+        for trail in 0xdc00..0xe000 {
+            // find the scalar value represented by the [lead, trail] pair.
+            let combined: Vec<char> = core::char::decode_utf16([lead, trail].iter().copied())
+                .collect::<Result<_, _>>()
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "[{:#04x}, {:#04x}] not valid surrogate pair? {:?}",
+                        lead, trail, e,
+                    );
+                });
+            assert_eq!(combined.len(), 1);
+            let expected_string = format!("{}", combined[0]);
+
+            let ron = format!(r#""\u{:04x}\u{:04x}""#, lead, trail);
+            let result: String = DeRon::deserialize_ron(&ron).unwrap_or_else(|e| {
+                panic!("should be able to parse {}: {:?}", &ron, e);
+            });
+            assert_eq!(result, expected_string, "failed on input {}", ron);
+            assert_eq!(result.chars().count(), 1);
+        }
+    }
 }


### PR DESCRIPTION
Adds serialization for RON based on the legacy code but adapted to be more similar to the nanoserde json/bin implementations. Also enables a few more types for RON deserialization, and proxy serialization/deserialization.

Tests were copied from the JSON tests and adapted for RON format. Some more tests might be useful for some of the functionality I added: hoping to flesh these out in review feedback.