### PR TITLE
json: Support rename attribute on enum variants and properly implement variants without fields

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -118,7 +118,6 @@ pub fn derive_de_json(input: proc_macro::TokenStream) -> proc_macro::TokenStream
     if let Some(proxy) = shared::attrs_proxy(&input.attributes()) {
         return derive_de_json_proxy(&proxy, &input.name());
     }
-
     // ok we have an ident, its either a struct or a enum
     let ts = match &input {
         parse::Data::Struct(struct_) if struct_.named => derive_de_json_struct(struct_),

--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -51,7 +51,9 @@ pub struct EnumVariant {
     pub name: String,
     pub named: bool,
     pub fields: Vec<Field>,
+    pub attributes: Vec<Attribute>,
 }
+
 #[derive(Debug)]
 pub struct Enum {
     pub name: String,
@@ -399,7 +401,7 @@ fn next_enum(mut source: &mut Peekable<impl Iterator<Item = TokenTree>>) -> Enum
             break;
         }
 
-        let _attributes = next_attributes_list(&mut body);
+        let attributes = next_attributes_list(&mut body);
 
         let variant_name = next_ident(&mut body).expect("Unnamed variants are not supported");
         let group = next_group(&mut body);
@@ -408,6 +410,7 @@ fn next_enum(mut source: &mut Peekable<impl Iterator<Item = TokenTree>>) -> Enum
                 name: variant_name,
                 named: false,
                 fields: vec![],
+                attributes,
             });
             let _maybe_comma = next_exact_punct(&mut body, ",");
             continue;
@@ -427,6 +430,7 @@ fn next_enum(mut source: &mut Peekable<impl Iterator<Item = TokenTree>>) -> Enum
                 name: variant_name,
                 named,
                 fields,
+                attributes,
             });
         }
         let _maybe_semicolon = next_exact_punct(&mut body, ";");

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -121,17 +121,31 @@ fn rename() {
         #[nserde(rename = "fooField")]
         pub a: i32,
         #[nserde(rename = "barField")]
-        pub b: i32,
+        pub b: Bar,
+    }
+
+    #[derive(DeJson, SerJson, PartialEq, Debug)]
+    pub enum Bar {
+        #[nserde(rename = "fooValue")]
+        A,
+        #[nserde(rename = "barValue")]
+        B,
+    }
+
+    impl Default for Bar {
+        fn default() -> Self {
+            Self::A
+        }
     }
 
     let json = r#"{
         "fooField": 1,
-        "barField": 2,
+        "barField": "fooValue",
     }"#;
 
     let test: Test = DeJson::deserialize_json(json).unwrap();
     assert_eq!(test.a, 1);
-    assert_eq!(test.b, 2);
+    assert_eq!(test.b, Bar::A);
 
     let bytes = SerJson::serialize_json(&test);
     let test_deserialized = DeJson::deserialize_json(&bytes).unwrap();
@@ -433,7 +447,7 @@ fn de_enum() {
 
     let json = r#"
        {
-          "foo1": { "A": [] },
+          "foo1": "A",
           "foo2": { "B": [ 1, "asd" ] },
           "foo3": { "C": { "a": 2, "b": "qwe" } }
        }
@@ -470,7 +484,7 @@ fn de_ser_enum() {
 
     let json = r#"
        {
-          "foo1": { "A": [] },
+          "foo1": "A",
           "foo2": { "B": {"x": 5} },
           "foo3": { "C": [6, "HELLO"] }
        }


### PR DESCRIPTION
This is pretty much a fix for all mentioned in #33
I added new test cases and fixed the old ones to expect the actual serde-json behavior