### PR TITLE
json: add support for #[nserde(default = "value")] and #[nserde(default_with = "fn")]

### DIFF
--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -132,9 +132,7 @@ pub fn next_exact_punct(
     return None;
 }
 
-pub fn next_literal(
-    source: &mut Peekable<impl Iterator<Item = TokenTree>>,
-) -> Option<String> {
+pub fn next_literal(source: &mut Peekable<impl Iterator<Item = TokenTree>>) -> Option<String> {
     if let Some(TokenTree::Literal(lit)) = source.peek() {
         let mut literal = lit.to_string();
 

--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -11,7 +11,7 @@ use std::iter::Peekable;
 #[derive(Debug)]
 pub struct Attribute {
     pub name: String,
-    pub tokens: Vec<(String, bool)>,
+    pub tokens: Vec<String>,
 }
 
 #[allow(dead_code)]
@@ -134,19 +134,17 @@ pub fn next_exact_punct(
 
 pub fn next_literal(
     source: &mut Peekable<impl Iterator<Item = TokenTree>>,
-) -> Option<(String, bool)> {
+) -> Option<String> {
     if let Some(TokenTree::Literal(lit)) = source.peek() {
         let mut literal = lit.to_string();
 
-        let mut is_string = false;
         // the only way to check that literal is string :/
         if literal.starts_with("\"") {
             literal.remove(0);
             literal.remove(literal.len() - 1);
-            is_string = true;
         }
         source.next();
-        return Some((literal, is_string));
+        return Some(literal);
     }
 
     return None;
@@ -271,7 +269,7 @@ fn next_attribute<T: Iterator<Item = TokenTree>>(
 
         loop {
             let attribute_name = next_ident(&mut args_group).expect("Expecting attribute name");
-            attr_tokens.push((attribute_name, false));
+            attr_tokens.push(attribute_name);
 
             // single-word attribute, like #[nserde(whatever)]
             if next_eof(&mut args_group).is_some() {

--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -90,7 +90,14 @@ pub fn derive_de_json_named(name: &str, defaults: bool, fields: &[Field]) -> Tok
         let field_attr_default = shared::attrs_default(&field.attributes);
         let field_attr_default_with = shared::attrs_default_with(&field.attributes);
         let default_val = if let Some(v) = field_attr_default {
-            Some(v.unwrap_or_else(|| String::from("Default::default()")))
+            if let Some((mut val, is_string)) = v {
+                if is_string && field.ty.path == "String" {
+                    val = format!("\"{}\".to_string()", val)
+                }
+                Some(val)
+            } else {
+                Some(String::from("Default::default()"))
+            }
         } else if let Some(mut v) = field_attr_default_with {
             v.push_str("()");
             Some(v)

--- a/derive/src/serde_ron.rs
+++ b/derive/src/serde_ron.rs
@@ -121,13 +121,20 @@ pub fn derive_de_ron_named(
         let field_attr_default = shared::attrs_default(&field.attributes);
         let field_attr_default_with = shared::attrs_default_with(&field.attributes);
         let default_val = if let Some(v) = field_attr_default {
-            if let Some((mut val, is_string)) = v {
-                if is_string && field.ty.path == "String" {
+            if let Some(mut val) = v {
+                if field.ty.path == "String" {
                     val = format!("\"{}\".to_string()", val)
+                }
+                if field.ty.is_option {
+                    val = format!("Some({})", val);
                 }
                 Some(val)
             } else {
-                Some(String::from("Default::default()"))
+                if !field.ty.is_option {
+                    Some(String::from("Default::default()"))
+                } else {
+                    Some(String::from("None"))
+                }
             }
         } else if let Some(mut v) = field_attr_default_with {
             v.push_str("()");
@@ -144,10 +151,11 @@ pub fn derive_de_ron_named(
                     if let Some(t) = {} {{
                         t
                     }} else {{
-                        None
+                        {}
                     }}
                 }}",
-                localvar
+                localvar,
+                default_val.unwrap_or_else(|| String::from("None"))
             ));
         } else if container_attr_default || default_val.is_some() {
             unwraps.push(format!(

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -28,10 +28,16 @@ pub fn attrs_rename(attributes: &[crate::parse::Attribute]) -> Option<String> {
     })
 }
 
-pub fn attrs_default(attributes: &[crate::parse::Attribute]) -> bool {
-    attributes
-        .iter()
-        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "default")
+pub fn attrs_default(attributes: &[crate::parse::Attribute]) -> Option<Option<String>> {
+    attributes.iter().find_map(|attr| {
+        if attr.tokens.len() == 1 && attr.tokens[0] == "default" {
+            Some(None)
+        } else if attr.tokens.len() == 2 && attr.tokens[0] == "default" {
+            Some(Some(attr.tokens[1].clone()))
+        } else {
+            None
+        }
+    })
 }
 
 pub fn attrs_transparent(attributes: &[crate::parse::Attribute]) -> bool {

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -40,6 +40,16 @@ pub fn attrs_default(attributes: &[crate::parse::Attribute]) -> Option<Option<St
     })
 }
 
+pub fn attrs_default_with(attributes: &[crate::parse::Attribute]) -> Option<String> {
+    attributes.iter().find_map(|attr| {
+        if attr.tokens.len() == 2 && attr.tokens[0] == "default_with" {
+            Some(attr.tokens[1].clone())
+        } else {
+            None
+        }
+    })
+}
+
 pub fn attrs_transparent(attributes: &[crate::parse::Attribute]) -> bool {
     attributes
         .iter()

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -10,8 +10,8 @@ macro_rules! l {
 
 pub fn attrs_proxy(attributes: &[crate::parse::Attribute]) -> Option<String> {
     attributes.iter().find_map(|attr| {
-        if attr.tokens.len() == 2 && attr.tokens[0] == "proxy" {
-            Some(attr.tokens[1].clone())
+        if attr.tokens.len() == 2 && attr.tokens[0].0 == "proxy" {
+            Some(attr.tokens[1].0.clone())
         } else {
             None
         }
@@ -20,19 +20,19 @@ pub fn attrs_proxy(attributes: &[crate::parse::Attribute]) -> Option<String> {
 
 pub fn attrs_rename(attributes: &[crate::parse::Attribute]) -> Option<String> {
     attributes.iter().find_map(|attr| {
-        if attr.tokens.len() == 2 && attr.tokens[0] == "rename" {
-            Some(attr.tokens[1].clone())
+        if attr.tokens.len() == 2 && attr.tokens[0].0 == "rename" {
+            Some(attr.tokens[1].0.clone())
         } else {
             None
         }
     })
 }
 
-pub fn attrs_default(attributes: &[crate::parse::Attribute]) -> Option<Option<String>> {
+pub fn attrs_default(attributes: &[crate::parse::Attribute]) -> Option<Option<(String, bool)>> {
     attributes.iter().find_map(|attr| {
-        if attr.tokens.len() == 1 && attr.tokens[0] == "default" {
+        if attr.tokens.len() == 1 && attr.tokens[0].0 == "default" {
             Some(None)
-        } else if attr.tokens.len() == 2 && attr.tokens[0] == "default" {
+        } else if attr.tokens.len() == 2 && attr.tokens[0].0 == "default" {
             Some(Some(attr.tokens[1].clone()))
         } else {
             None
@@ -42,8 +42,8 @@ pub fn attrs_default(attributes: &[crate::parse::Attribute]) -> Option<Option<St
 
 pub fn attrs_default_with(attributes: &[crate::parse::Attribute]) -> Option<String> {
     attributes.iter().find_map(|attr| {
-        if attr.tokens.len() == 2 && attr.tokens[0] == "default_with" {
-            Some(attr.tokens[1].clone())
+        if attr.tokens.len() == 2 && attr.tokens[0].0 == "default_with" {
+            Some(attr.tokens[1].0.clone())
         } else {
             None
         }
@@ -53,11 +53,11 @@ pub fn attrs_default_with(attributes: &[crate::parse::Attribute]) -> Option<Stri
 pub fn attrs_transparent(attributes: &[crate::parse::Attribute]) -> bool {
     attributes
         .iter()
-        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "transparent")
+        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0].0 == "transparent")
 }
 
 pub fn attrs_skip(attributes: &[crate::parse::Attribute]) -> bool {
     attributes
         .iter()
-        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "skip")
+        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0].0 == "skip")
 }

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -10,8 +10,8 @@ macro_rules! l {
 
 pub fn attrs_proxy(attributes: &[crate::parse::Attribute]) -> Option<String> {
     attributes.iter().find_map(|attr| {
-        if attr.tokens.len() == 2 && attr.tokens[0].0 == "proxy" {
-            Some(attr.tokens[1].0.clone())
+        if attr.tokens.len() == 2 && attr.tokens[0] == "proxy" {
+            Some(attr.tokens[1].clone())
         } else {
             None
         }
@@ -20,19 +20,19 @@ pub fn attrs_proxy(attributes: &[crate::parse::Attribute]) -> Option<String> {
 
 pub fn attrs_rename(attributes: &[crate::parse::Attribute]) -> Option<String> {
     attributes.iter().find_map(|attr| {
-        if attr.tokens.len() == 2 && attr.tokens[0].0 == "rename" {
-            Some(attr.tokens[1].0.clone())
+        if attr.tokens.len() == 2 && attr.tokens[0] == "rename" {
+            Some(attr.tokens[1].clone())
         } else {
             None
         }
     })
 }
 
-pub fn attrs_default(attributes: &[crate::parse::Attribute]) -> Option<Option<(String, bool)>> {
+pub fn attrs_default(attributes: &[crate::parse::Attribute]) -> Option<Option<String>> {
     attributes.iter().find_map(|attr| {
-        if attr.tokens.len() == 1 && attr.tokens[0].0 == "default" {
+        if attr.tokens.len() == 1 && attr.tokens[0] == "default" {
             Some(None)
-        } else if attr.tokens.len() == 2 && attr.tokens[0].0 == "default" {
+        } else if attr.tokens.len() == 2 && attr.tokens[0] == "default" {
             Some(Some(attr.tokens[1].clone()))
         } else {
             None
@@ -42,8 +42,8 @@ pub fn attrs_default(attributes: &[crate::parse::Attribute]) -> Option<Option<(S
 
 pub fn attrs_default_with(attributes: &[crate::parse::Attribute]) -> Option<String> {
     attributes.iter().find_map(|attr| {
-        if attr.tokens.len() == 2 && attr.tokens[0].0 == "default_with" {
-            Some(attr.tokens[1].0.clone())
+        if attr.tokens.len() == 2 && attr.tokens[0] == "default_with" {
+            Some(attr.tokens[1].clone())
         } else {
             None
         }
@@ -53,11 +53,11 @@ pub fn attrs_default_with(attributes: &[crate::parse::Attribute]) -> Option<Stri
 pub fn attrs_transparent(attributes: &[crate::parse::Attribute]) -> bool {
     attributes
         .iter()
-        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0].0 == "transparent")
+        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "transparent")
 }
 
 pub fn attrs_skip(attributes: &[crate::parse::Attribute]) -> bool {
     attributes
         .iter()
-        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0].0 == "skip")
+        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "skip")
 }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -184,6 +184,10 @@ fn de_field_default() {
         e: String,
         #[nserde(default = "Bar{x:3}")]
         f: Bar,
+        #[nserde(default = 5)]
+        g: Option<i32>,
+        #[nserde(default = "world")]
+        h: Option<String>,
     }
 
     fn some_value() -> f32 {
@@ -202,6 +206,8 @@ fn de_field_default() {
     assert_eq!(test.d, 1);
     assert_eq!(test.e, "hello");
     assert_eq!(test.f.x, 3);
+    assert_eq!(test.g, Some(5));
+    assert_eq!(test.h, Some(String::from("world")));
     assert_eq!(test.foo.x, 23);
     assert_eq!(test.foo2.x, 3);
 }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -164,15 +164,26 @@ fn de_field_default() {
     }
 
     #[derive(DeJson)]
+    struct Bar {
+        x: i32,
+    }
+
+    #[derive(DeJson)]
     pub struct Test {
         a: i32,
         #[nserde(default)]
         foo: Foo,
         foo2: Foo,
-        #[nserde(default = "4.0")]
+        #[nserde(default = 4.0)]
         b: f32,
         #[nserde(default_with = "some_value")]
         c: f32,
+        #[nserde(default = 1)]
+        d: i32,
+        #[nserde(default = "hello")]
+        e: String,
+        #[nserde(default = "Bar{x:3}")]
+        f: Bar,
     }
 
     fn some_value() -> f32 {
@@ -188,6 +199,9 @@ fn de_field_default() {
     assert_eq!(test.a, 1);
     assert_eq!(test.b, 4.0);
     assert_eq!(test.c, 3.0);
+    assert_eq!(test.d, 1);
+    assert_eq!(test.e, "hello");
+    assert_eq!(test.f.x, 3);
     assert_eq!(test.foo.x, 23);
     assert_eq!(test.foo2.x, 3);
 }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -164,11 +164,6 @@ fn de_field_default() {
     }
 
     #[derive(DeJson)]
-    struct Bar {
-        x: i32,
-    }
-
-    #[derive(DeJson)]
     pub struct Test {
         a: i32,
         #[nserde(default)]
@@ -182,8 +177,8 @@ fn de_field_default() {
         d: i32,
         #[nserde(default = "hello")]
         e: String,
-        #[nserde(default = "Bar{x:3}")]
-        f: Bar,
+        #[nserde(default = "Foo{x:3}")]
+        f: Foo,
         #[nserde(default = 5)]
         g: Option<i32>,
         #[nserde(default = "world")]

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -169,8 +169,10 @@ fn de_field_default() {
         #[nserde(default)]
         foo: Foo,
         foo2: Foo,
-        #[nserde(default = "some_value")]
+        #[nserde(default = "4.0")]
         b: f32,
+        #[nserde(default_with = "some_value")]
+        c: f32,
     }
 
     fn some_value() -> f32 {
@@ -184,7 +186,8 @@ fn de_field_default() {
 
     let test: Test = DeJson::deserialize_json(json).unwrap();
     assert_eq!(test.a, 1);
-    assert_eq!(test.b, 3.0);
+    assert_eq!(test.b, 4.0);
+    assert_eq!(test.c, 3.0);
     assert_eq!(test.foo.x, 23);
     assert_eq!(test.foo2.x, 3);
 }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -41,7 +41,6 @@ fn de_options() {
     assert_eq!(test.b, Some("qwe".to_string()));
 }
 
-
 #[test]
 fn de_option_one_field() {
     #[derive(DeJson)]
@@ -170,18 +169,22 @@ fn de_field_default() {
         #[nserde(default)]
         foo: Foo,
         foo2: Foo,
+        #[nserde(default = "some_value")]
         b: f32,
+    }
+
+    fn some_value() -> f32 {
+        3.0
     }
 
     let json = r#"{
         "a": 1,
-        "b": 2.,
         "foo2": { "x": 3 }
     }"#;
 
     let test: Test = DeJson::deserialize_json(json).unwrap();
     assert_eq!(test.a, 1);
-    assert_eq!(test.b, 2.);
+    assert_eq!(test.b, 3.0);
     assert_eq!(test.foo.x, 23);
     assert_eq!(test.foo2.x, 3);
 }


### PR DESCRIPTION
This is supported by serde and currently not possible without hacky wrapper structs in nanoserde. I did run `cargo fmt` on the code after so some of this is just changes by rustfmt. Test has been adjusted.