### PR TITLE
Fix UB in DeBin impl for usize

### DIFF
--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -125,23 +125,20 @@ impl SerBin for usize {
 impl DeBin for usize {
     fn de_bin(o: &mut usize, d: &[u8]) -> Result<usize, DeBinErr> {
         let l = std::mem::size_of::<u64>();
-        if *o + l > d.len() {
-            return Err(DeBinErr {
-                o: *o,
-                l: l,
-                s: d.len(),
-            });
-        }
-        let mut m = [0 as u64];
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                d.as_ptr().offset(*o as isize) as *const u64,
-                m.as_mut_ptr() as *mut u64,
-                1,
-            )
-        }
+
+        let m = match d.get(*o..*o + l) {
+            Some(data) => u64::from_ne_bytes(data.try_into().unwrap()),
+            None => {
+                return Err(DeBinErr {
+                    o: *o,
+                    l,
+                    s: d.len(),
+                });
+            }
+        };
+
         *o += l;
-        Ok(m[0] as usize)
+        Ok(m as usize)
     }
 }
 


### PR DESCRIPTION
Running the current tests (specifically the `binary` test) under miri shows that there is Undefined Behavior in the DeBin impl for usize:
```rs
test binary ... error: 
Undefined Behavior: accessing memory with alignment 1, but alignment 8 is required
    --> /root/.rustup/toolchains/miri/lib/rustlib/src/rust/library/core/src/intrinsics.rs:2137:9
     |
2137 |         copy_nonoverlapping(src, dst, count)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment 1, but alignment 8 is required
```
One of the safety requirements for copy_nonoverlapping is that both `src` and `dest` must be properly aligned, but src is not when cast from `*const u8` to `*const u64` here:
https://github.com/not-fl3/nanoserde/blob/377e6cf9f980b9cac18a84658f5e3604ecae5188/src/serde_bin.rs#L138

The fix in this PR rewrites `copy_nonoverlapping` to use `u64::from_ne_bytes`, which I think is what the current implementation is trying to do.
This makes miri pass.

(Also, I believe  the current implementation reads out of bounds under very specific conditions, such as when `2^64-8 > o <= 2^64`, because `*o + l` in the condition will overflow and that makes the check pass, however that's more of a theoretical issue than a practical one because such a large slice is impossible in todays world)