### PR TITLE
Added beginning support for generics to serbin and debin proc macros

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -9,4 +9,9 @@ license = "MIT"
 [lib]
 proc-macro = true
 
+[features]
+default = []
+no_std = ["dep:hashbrown"]
+
 [dependencies]
+hashbrown = { version = "0.12.3", optional = true }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,4 +1,7 @@
-#![no_std]
+#![cfg_attr(features = "no_std", no_std)]
+// Possibly stable in 1.65.
+// See: https://github.com/rust-lang/rust/pull/99917
+#![cfg_attr(features = "no_std", feature(error_in_core))]
 
 extern crate alloc;
 extern crate proc_macro;

--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -13,6 +13,13 @@ use alloc::{format, vec};
 use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 
 
+#[cfg(features = "no_std")]
+use hashbrown::HashSet;
+
+#[cfg(not(features = "no_std"))]
+use std::collections::HashSet;
+
+
 #[derive(Debug)]
 pub struct Attribute {
     pub name: String,

--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -10,7 +10,6 @@ use hashbrown::HashMap;
 
 #[cfg(not(features = "no_std"))]
 use std::collections::HashMap;
-use core::hash::Hash;
 
 /// A trait for objects that can be serialized to binary.
 pub trait SerBin {

--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -10,6 +10,7 @@ use hashbrown::HashMap;
 
 #[cfg(not(features = "no_std"))]
 use std::collections::HashMap;
+use core::hash::Hash;
 
 /// A trait for objects that can be serialized to binary.
 pub trait SerBin {

--- a/tests/bin.rs
+++ b/tests/bin.rs
@@ -25,6 +25,36 @@ fn binary() {
 }
 
 #[test]
+fn binary_generics() {
+    #[derive(DeBin, SerBin, PartialEq)]
+    pub struct TestStruct<A, B> {
+        pub a: A,
+        b: Option<B>,
+    }
+
+    let test: TestStruct<i32, f32> = TestStruct { a: 1, b: Some(2.) };
+
+    let bytes = SerBin::serialize_bin(&test);
+
+    let test_deserialized = DeBin::deserialize_bin(&bytes).unwrap();
+
+    assert!(test == test_deserialized);
+
+    #[derive(DeBin, SerBin, PartialEq)]
+    pub enum TestEnum<A, B> {
+        Test(A, B),
+    }
+
+    let test: TestEnum<i32, f32> = TestEnum::Test(3, 15.);
+
+    let bytes = SerBin::serialize_bin(&test);
+
+    let test_deserialized = DeBin::deserialize_bin(&bytes).unwrap();
+
+    assert!(test == test_deserialized);
+}
+
+#[test]
 fn field_proxy() {
     #[derive(PartialEq)]
     pub struct NonSerializable {


### PR DESCRIPTION
Did some work on the proc macros and they can now derive impls for some structs and enums with generics. Where bounds probably wont work yet. Should be reusable work for the json and ron macros as well