### PR TITLE
Make derive macros use fully-qualified paths

### DIFF
--- a/derive/src/serde_bin.rs
+++ b/derive/src/serde_bin.rs
@@ -21,7 +21,7 @@ pub fn derive_de_bin_proxy(proxy_type: &str, type_: &str) -> TokenStream {
         "impl ::nanoserde::DeBin for {} {{
             fn de_bin(o:&mut usize, d:&[u8]) -> ::std::result::Result<Self, ::nanoserde::DeBinErr> {{
                 let proxy: {} = ::nanoserde::DeBin::de_bin(o, d)?;
-                ::std::result::Result::Ok(::std::convert::Into::into(&proxy))
+                ::std::result::Result::Ok(Into::into(&proxy))
             }}
         }}",
         type_, proxy_type
@@ -37,7 +37,7 @@ pub fn derive_ser_bin_struct(struct_: &Struct) -> TokenStream {
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(
                 body,
-                "let proxy: {} = ::std::convert::Into::into(&self.{});",
+                "let proxy: {} = Into::into(&self.{});",
                 proxy,
                 field.field_name.as_ref().unwrap()
             );
@@ -67,7 +67,7 @@ pub fn derive_ser_bin_struct_unnamed(struct_: &Struct) -> TokenStream {
 
     for (n, field) in struct_.fields.iter().enumerate() {
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
-            l!(body, "let proxy: {} = ::std::convert::Into::into(&self.{});", proxy, n);
+            l!(body, "let proxy: {} = Into::into(&self.{});", proxy, n);
             l!(body, "proxy.ser_bin(s);");
         } else {
             l!(body, "self.{}.ser_bin(s);", n);
@@ -92,7 +92,7 @@ pub fn derive_de_bin_struct(struct_: &Struct) -> TokenStream {
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(body, "{}: {{", field.field_name.as_ref().unwrap());
             l!(body, "let proxy: {} = ::nanoserde::DeBin::de_bin(o, d)?;", proxy);
-            l!(body, "::std::convert::Into::into(&proxy)");
+            l!(body, "Into::into(&proxy)");
             l!(body, "},")
         } else {
             l!(
@@ -124,7 +124,7 @@ pub fn derive_de_bin_struct_unnamed(struct_: &Struct) -> TokenStream {
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(body, "{}: {{", n);
             l!(body, "let proxy: {} = ::nanoserde::DeBin::de_bin(o, d)?;", proxy);
-            l!(body, "::std::convert::Into::into(&proxy)");
+            l!(body, "Into::into(&proxy)");
             l!(body, "},")
         } else {
             l!(body, "{}: ::nanoserde::DeBin::de_bin(o, d)?,", n);

--- a/derive/src/serde_bin.rs
+++ b/derive/src/serde_bin.rs
@@ -4,8 +4,8 @@ use proc_macro::TokenStream;
 
 pub fn derive_ser_bin_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
-        "impl SerBin for {} {{
-            fn ser_bin(&self, s: &mut Vec<u8>) {{
+        "impl ::nanoserde::SerBin for {} {{
+            fn ser_bin(&self, s: &mut ::std::vec::Vec<u8>) {{
                 let proxy: {} = self.into();
                 proxy.ser_bin(s);
             }}
@@ -18,10 +18,10 @@ pub fn derive_ser_bin_proxy(proxy_type: &str, type_: &str) -> TokenStream {
 
 pub fn derive_de_bin_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
-        "impl DeBin for {} {{
-            fn de_bin(o:&mut usize, d:&[u8]) -> std::result::Result<Self, nanoserde::DeBinErr> {{
-                let proxy: {} = DeBin::de_bin(o, d)?;
-                std::result::Result::Ok(Into::into(&proxy))
+        "impl ::nanoserde::DeBin for {} {{
+            fn de_bin(o:&mut usize, d:&[u8]) -> ::std::result::Result<Self, ::nanoserde::DeBinErr> {{
+                let proxy: {} = ::nanoserde::DeBin::de_bin(o, d)?;
+                ::std::result::Result::Ok(::std::convert::Into::into(&proxy))
             }}
         }}",
         type_, proxy_type
@@ -37,7 +37,7 @@ pub fn derive_ser_bin_struct(struct_: &Struct) -> TokenStream {
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(
                 body,
-                "let proxy: {} = Into::into(&self.{});",
+                "let proxy: {} = ::std::convert::Into::into(&self.{});",
                 proxy,
                 field.field_name.as_ref().unwrap()
             );
@@ -51,8 +51,8 @@ pub fn derive_ser_bin_struct(struct_: &Struct) -> TokenStream {
         }
     }
     format!(
-        "impl SerBin for {} {{
-            fn ser_bin(&self, s: &mut Vec<u8>) {{
+        "impl ::nanoserde::SerBin for {} {{
+            fn ser_bin(&self, s: &mut ::std::vec::Vec<u8>) {{
                 {}
             }}
         }}",
@@ -67,15 +67,15 @@ pub fn derive_ser_bin_struct_unnamed(struct_: &Struct) -> TokenStream {
 
     for (n, field) in struct_.fields.iter().enumerate() {
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
-            l!(body, "let proxy: {} = Into::into(&self.{});", proxy, n);
+            l!(body, "let proxy: {} = ::std::convert::Into::into(&self.{});", proxy, n);
             l!(body, "proxy.ser_bin(s);");
         } else {
             l!(body, "self.{}.ser_bin(s);", n);
         }
     }
     format!(
-        "impl SerBin for {} {{
-            fn ser_bin(&self, s: &mut Vec<u8>) {{
+        "impl ::nanoserde::SerBin for {} {{
+            fn ser_bin(&self, s: &mut ::std::vec::Vec<u8>) {{
                 {}
             }}
         }}",
@@ -91,22 +91,22 @@ pub fn derive_de_bin_struct(struct_: &Struct) -> TokenStream {
     for field in &struct_.fields {
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(body, "{}: {{", field.field_name.as_ref().unwrap());
-            l!(body, "let proxy: {} = DeBin::de_bin(o, d)?;", proxy);
-            l!(body, "Into::into(&proxy)");
+            l!(body, "let proxy: {} = ::nanoserde::DeBin::de_bin(o, d)?;", proxy);
+            l!(body, "::std::convert::Into::into(&proxy)");
             l!(body, "},")
         } else {
             l!(
                 body,
-                "{}: DeBin::de_bin(o, d)?,",
+                "{}: ::nanoserde::DeBin::de_bin(o, d)?,",
                 field.field_name.as_ref().unwrap()
             );
         }
     }
 
     format!(
-        "impl DeBin for {} {{
-            fn de_bin(o:&mut usize, d:&[u8]) -> std::result::Result<Self, nanoserde::DeBinErr> {{
-                std::result::Result::Ok(Self {{
+        "impl ::nanoserde::DeBin for {} {{
+            fn de_bin(o:&mut usize, d:&[u8]) -> ::std::result::Result<Self, ::nanoserde::DeBinErr> {{
+                ::std::result::Result::Ok(Self {{
                     {}
                 }})
             }}
@@ -123,18 +123,18 @@ pub fn derive_de_bin_struct_unnamed(struct_: &Struct) -> TokenStream {
     for (n, field) in struct_.fields.iter().enumerate() {
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(body, "{}: {{", n);
-            l!(body, "let proxy: {} = DeBin::de_bin(o, d)?;", proxy);
-            l!(body, "Into::into(&proxy)");
+            l!(body, "let proxy: {} = ::nanoserde::DeBin::de_bin(o, d)?;", proxy);
+            l!(body, "::std::convert::Into::into(&proxy)");
             l!(body, "},")
         } else {
-            l!(body, "{}: DeBin::de_bin(o, d)?,", n);
+            l!(body, "{}: ::nanoserde::DeBin::de_bin(o, d)?,", n);
         }
     }
 
     format!(
         "impl DeBin for {} {{
-            fn de_bin(o:&mut usize, d:&[u8]) -> std::result::Result<Self, nanoserde::DeBinErr> {{
-                std::result::Result::Ok(Self {{
+            fn de_bin(o:&mut usize, d:&[u8]) -> ::std::result::Result<Self, ::nanoserde::DeBinErr> {{
+                ::std::result::Result::Ok(Self {{
                     {}
                 }})
             }}
@@ -184,8 +184,8 @@ pub fn derive_ser_bin_enum(enum_: &Enum) -> TokenStream {
     }
 
     format!(
-        "impl SerBin for {} {{
-            fn ser_bin(&self, s: &mut Vec<u8>) {{
+        "impl ::nanoserde::SerBin for {} {{
+            fn ser_bin(&self, s: &mut ::std::vec::Vec<u8>) {{
                 match self {{
                   {}
                 }}
@@ -213,7 +213,7 @@ pub fn derive_de_bin_enum(enum_: &Enum) -> TokenStream {
             for field in &variant.fields {
                 l!(
                     r,
-                    "{}: DeBin::de_bin(o, d)?,",
+                    "{}: ::nanoserde::DeBin::de_bin(o, d)?,",
                     field.field_name.as_ref().unwrap()
                 );
             }
@@ -223,19 +223,19 @@ pub fn derive_de_bin_enum(enum_: &Enum) -> TokenStream {
         else if variant.named == false {
             l!(r, "{} => Self::{} (", lit, variant.name);
             for _ in &variant.fields {
-                l!(r, "DeBin::de_bin(o, d)?,");
+                l!(r, "::nanoserde::DeBin::de_bin(o, d)?,");
             }
             l!(r, "),");
         }
     }
 
     format!(
-        "impl  DeBin for {} {{
-            fn de_bin(o:&mut usize, d:&[u8]) -> std::result::Result<Self, nanoserde::DeBinErr> {{
-                let id: u16 = DeBin::de_bin(o,d)?;
+        "impl ::nanoserde::DeBin for {} {{
+            fn de_bin(o:&mut usize, d:&[u8]) -> ::std::result::Result<Self, ::nanoserde::DeBinErr> {{
+                let id: u16 = ::nanoserde::DeBin::de_bin(o,d)?;
                 Ok(match id {{
                     {}
-                    _ => return std::result::Result::Err(nanoserde::DeBinErr{{o:*o, l:0, s:d.len()}})
+                    _ => return ::std::result::Result::Err(::nanoserde::DeBinErr{{o:*o, l:0, s:d.len()}})
                 }})
             }}
         }}", enum_.name, r)

--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -6,8 +6,8 @@ use crate::shared;
 
 pub fn derive_ser_json_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
-        "impl SerJson for {} {{
-            fn ser_json(&self, d: usize, s: &mut nanoserde::SerJsonState) {{
+        "impl ::nanoserde::SerJson for {} {{
+            fn ser_json(&self, d: usize, s: &mut ::nanoserde::SerJsonState) {{
                 let proxy: {} = self.into();
                 proxy.ser_json(d, s);
             }}
@@ -34,7 +34,7 @@ pub fn derive_ser_json_struct(struct_: &Struct) -> TokenStream {
             }
             let proxied_field = if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
                 format!(
-                    "{{let proxy: {} = Into::into(&self.{});proxy}}",
+                    "{{let proxy: {} = ::std::convert::Into::into(&self.{});proxy}}",
                     proxy, struct_fieldname
                 )
             } else {
@@ -61,8 +61,8 @@ pub fn derive_ser_json_struct(struct_: &Struct) -> TokenStream {
 
     format!(
         "
-        impl SerJson for {} {{
-            fn ser_json(&self, d: usize, s: &mut nanoserde::SerJsonState) {{
+        impl ::nanoserde::SerJson for {} {{
+            fn ser_json(&self, d: usize, s: &mut ::nanoserde::SerJsonState) {{
                 s.st_pre();
                 {}
                 s.st_post(d);
@@ -95,14 +95,14 @@ pub fn derive_de_json_named(name: &str, defaults: bool, fields: &[Field]) -> Tok
                     val = format!("\"{}\".to_string()", val)
                 }
                 if field.ty.is_option {
-                    val = format!("Some({})", val);
+                    val = format!("::std::option::Option::Some({})", val);
                 }
                 Some(val)
             } else {
                 if !field.ty.is_option {
-                    Some(String::from("Default::default()"))
+                    Some(String::from("::std::default::Default::default()"))
                 } else {
-                    Some(String::from("None"))
+                    Some(String::from("::std::option::Option::None"))
                 }
             }
         } else if let Some(mut v) = field_attr_default_with {
@@ -117,7 +117,7 @@ pub fn derive_de_json_named(name: &str, defaults: bool, fields: &[Field]) -> Tok
         let skip = crate::shared::attrs_skip(&field.attributes);
 
         let proxified_t = if let Some(proxy) = proxy {
-            format!("From::<&{}>::from(&t)", proxy)
+            format!("::std::convert::From::<&{}>::from(&t)", proxy)
         } else {
             format!("t")
         };
@@ -125,28 +125,28 @@ pub fn derive_de_json_named(name: &str, defaults: bool, fields: &[Field]) -> Tok
         if skip == false {
             if field.ty.is_option {
                 unwraps.push(format!(
-                    "{{if let Some(t) = {} {{ {} }} else {{ {} }} }}",
+                    "{{if let ::std::option::Option::Some(t) = {} {{ {} }} else {{ {} }} }}",
                     localvar,
                     proxified_t,
-                    default_val.unwrap_or_else(|| String::from("None"))
+                    default_val.unwrap_or_else(|| String::from("::std::option::Option::None"))
                 ));
             } else if container_attr_default || default_val.is_some() {
                 unwraps.push(format!(
-                    "{{if let Some(t) = {} {{ {} }} else {{ {} }} }}",
+                    "{{if let ::std::option::Option::Some(t) = {} {{ {} }} else {{ {} }} }}",
                     localvar,
                     proxified_t,
-                    default_val.unwrap_or_else(|| String::from("Default::default()"))
+                    default_val.unwrap_or_else(|| String::from("::std::default::Default::default()"))
                 ));
             } else {
                 unwraps.push(format!(
-                    "{{if let Some(t) = {} {{ {} }} else {{return Err(s.err_nf(\"{}\"))}} }}",
+                    "{{if let ::std::option::Option::Some(t) = {} {{ {} }} else {{return ::std::result::Result::Err(s.err_nf(\"{}\"))}} }}",
                     localvar, proxified_t, struct_fieldname
                 ));
             }
             matches.push((json_fieldname.clone(), localvar.clone()));
             local_vars.push(localvar);
         } else {
-            unwraps.push(format!("None"));
+            unwraps.push(format!("::std::option::Option::None"));
         }
 
         struct_field_names.push(struct_fieldname);
@@ -155,17 +155,17 @@ pub fn derive_de_json_named(name: &str, defaults: bool, fields: &[Field]) -> Tok
 
     let mut r = String::new();
     for local_var in &local_vars {
-        l!(r, "let mut {} = None;", local_var);
+        l!(r, "let mut {} = ::std::option::Option::None;", local_var);
     }
     l!(r, "s.curly_open(i) ?;");
-    l!(r, "while let Some(_) = s.next_str() {");
+    l!(r, "while let ::std::option::Option::Some(_) = s.next_str() {");
 
     if json_field_names.len() != 0 {
-        l!(r, "match AsRef::<str>::as_ref(&s.strbuf) {");
+        l!(r, "match ::std::convert::AsRef::<str>::as_ref(&s.strbuf) {");
         for (json_field_name, local_var) in matches.iter() {
             l!(
                 r,
-                "\"{}\" => {{s.next_colon(i) ?;{} = Some(DeJson::de_json(s, i) ?)}},",
+                "\"{}\" => {{s.next_colon(i) ?;{} = ::std::option::Option::Some(::nanoserde::DeJson::de_json(s, i) ?)}},",
                 json_field_name,
                 local_var
             );
@@ -192,10 +192,10 @@ pub fn derive_de_json_named(name: &str, defaults: bool, fields: &[Field]) -> Tok
 
 pub fn derive_de_json_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
-        "impl DeJson for {} {{
-            fn de_json(_s: &mut nanoserde::DeJsonState, i: &mut std::str::Chars) -> std::result::Result<Self, nanoserde::DeJsonErr> {{
+        "impl ::nanoserde::DeJson for {} {{
+            fn de_json(_s: &mut ::nanoserde::DeJsonState, i: &mut ::std::str::Chars) -> ::std::result::Result<Self, ::nanoserde::DeJsonErr> {{
                 let proxy: {} = DeJson::deserialize_json(i)?;
-                std::result::Result::Ok(Into::into(&proxy))
+                ::std::result::Result::Ok(::std::convert::Into::into(&proxy))
             }}
         }}",
         type_, proxy_type
@@ -213,10 +213,10 @@ pub fn derive_de_json_struct(struct_: &Struct) -> TokenStream {
     );
 
     format!(
-        "impl DeJson for {} {{
-            fn de_json(s: &mut nanoserde::DeJsonState, i: &mut std::str::Chars) -> std::result::Result<Self,
-            nanoserde::DeJsonErr> {{
-                std::result::Result::Ok({{ {} }})
+        "impl ::nanoserde::DeJson for {} {{
+            fn de_json(s: &mut ::nanoserde::DeJsonState, i: &mut ::std::str::Chars) -> ::std::result::Result<Self,
+            ::nanoserde::DeJsonErr> {{
+                ::std::result::Result::Ok({{ {} }})
             }}
         }}", struct_.name, body)
         .parse().unwrap()
@@ -246,7 +246,7 @@ pub fn derive_ser_json_enum(enum_: &Enum) -> TokenStream {
                 if let Some(name) = &&field.field_name {
                     let proxied_field =
                         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
-                            format!("{{let proxy: {} = Into::into(&{});proxy}}", proxy, name)
+                            format!("{{let proxy: {} = ::std::convert::Into::into(&{});proxy}}", proxy, name)
                         } else {
                             format!("{}", name)
                         };
@@ -341,8 +341,8 @@ pub fn derive_ser_json_enum(enum_: &Enum) -> TokenStream {
 
     format!(
         "
-        impl SerJson for {} {{
-            fn ser_json(&self, d: usize, s: &mut nanoserde::SerJsonState) {{
+        impl ::nanoserde::SerJson for {} {{
+            fn ser_json(&self, d: usize, s: &mut ::nanoserde::SerJsonState) {{
                 match self {{
                     {}
                 }}
@@ -384,7 +384,7 @@ pub fn derive_de_json_enum(enum_: &Enum) -> TokenStream {
             for _ in &variant.fields {
                 l!(
                     field_names,
-                    "{let r = DeJson::de_json(s,i)?;s.eat_comma_block(i)?;r},"
+                    "{let r = ::nanoserde::DeJson::de_json(s,i)?;s.eat_comma_block(i)?;r},"
                 );
             }
             l!(
@@ -398,8 +398,8 @@ pub fn derive_de_json_enum(enum_: &Enum) -> TokenStream {
     }
 
     let mut r = format!(
-        "impl DeJson for {} {{
-            fn de_json(s: &mut nanoserde::DeJsonState, i: &mut std::str::Chars) -> std::result::Result<Self, nanoserde::DeJsonErr> {{
+        "impl ::nanoserde::DeJson for {} {{
+            fn de_json(s: &mut ::nanoserde::DeJsonState, i: &mut ::std::str::Chars) -> ::std::result::Result<Self, ::nanoserde::DeJsonErr> {{
                 match s.tok {{",
         enum_.name,
     );
@@ -407,13 +407,13 @@ pub fn derive_de_json_enum(enum_: &Enum) -> TokenStream {
     if !r_rest.is_empty() {
         r.push_str(&format!(
             "
-                    nanoserde::DeJsonTok::CurlyOpen => {{
+                    ::nanoserde::DeJsonTok::CurlyOpen => {{
                         s.curly_open(i)?;
                         let _ = s.string(i)?;
                         s.colon(i)?;
-                        let r = std::result::Result::Ok(match s.strbuf.as_ref() {{
+                        let r = ::std::result::Result::Ok(match s.strbuf.as_ref() {{
                             {}
-                            _ => return std::result::Result::Err(s.err_enum(&s.strbuf))
+                            _ => return ::std::result::Result::Err(s.err_enum(&s.strbuf))
                         }});
                         s.curly_close(i)?;
                         r
@@ -425,11 +425,11 @@ pub fn derive_de_json_enum(enum_: &Enum) -> TokenStream {
     if !r_units.is_empty() {
         r.push_str(&format!(
             "
-                    nanoserde::DeJsonTok::Str => {{
+                    ::nanoserde::DeJsonTok::Str => {{
                         let _ = s.string(i)?;
-                        std::result::Result::Ok(match s.strbuf.as_ref() {{
+                        ::std::result::Result::Ok(match s.strbuf.as_ref() {{
                             {}
-                            _ => return std::result::Result::Err(s.err_enum(&s.strbuf))
+                            _ => return ::std::result::Result::Err(s.err_enum(&s.strbuf))
                         }})
                     }},",
             r_units,
@@ -438,7 +438,7 @@ pub fn derive_de_json_enum(enum_: &Enum) -> TokenStream {
 
     r.push_str(
         r#"
-                    _ => std::result::Result::Err(s.err_token("String or {")),
+                    _ => ::std::result::Result::Err(s.err_token("String or {")),
                 }
             }
         }
@@ -478,8 +478,8 @@ pub fn derive_ser_json_struct_unnamed(struct_: &Struct) -> TokenStream {
 
     format!(
         "
-        impl SerJson for {} {{
-            fn ser_json(&self, d: usize, s: &mut nanoserde::SerJsonState) {{
+        impl ::nanoserde::SerJson for {} {{
+            fn ser_json(&self, d: usize, s: &mut ::nanoserde::SerJsonState) {{
                 {}
             }}
         }}",
@@ -495,7 +495,7 @@ pub fn derive_de_json_struct_unnamed(struct_: &Struct) -> TokenStream {
     let transparent = shared::attrs_transparent(&struct_.attributes);
 
     for _ in &struct_.fields {
-        l!(body, "{ let r = DeJson::de_json(s, i)?;");
+        l!(body, "{ let r = ::nanoserde::DeJson::de_json(s, i)?;");
         if struct_.fields.len() != 1 {
             l!(body, "  s.eat_comma_block(i)?;");
         }
@@ -523,10 +523,10 @@ pub fn derive_de_json_struct_unnamed(struct_: &Struct) -> TokenStream {
     };
 
     format! ("
-        impl DeJson for {} {{
-            fn de_json(s: &mut nanoserde::DeJsonState, i: &mut std::str::Chars) -> std::result::Result<Self,nanoserde::DeJsonErr> {{
+        impl ::nanoserde::DeJson for {} {{
+            fn de_json(s: &mut ::nanoserde::DeJsonState, i: &mut ::std::str::Chars) -> ::std::result::Result<Self, ::nanoserde::DeJsonErr> {{
                 {}
-                std::result::Result::Ok(r)
+                ::std::result::Result::Ok(r)
             }}
         }}",struct_.name, body
     ).parse().unwrap()

--- a/derive/src/serde_ron.rs
+++ b/derive/src/serde_ron.rs
@@ -23,7 +23,7 @@ pub fn derive_de_ron_proxy(proxy_type: &str, type_: &str) -> TokenStream {
         "impl ::nanoserde::DeRon for {} {{
             fn de_ron(_s: &mut ::nanoserde::DeRonState, i: &mut ::std::str::Chars) -> ::std::result::Result<Self, ::nanoserde::DeRonErr> {{
                 let proxy: {} = ::nanoserde::DeRon::deserialize_ron(i)?;
-                ::std::result::Result::Ok(::std::convert::Into::into(&proxy))
+                ::std::result::Result::Ok(Into::into(&proxy))
             }}
         }}",
         type_, proxy_type
@@ -42,7 +42,7 @@ pub fn derive_ser_ron_struct(struct_: &Struct) -> TokenStream {
         if field.ty.is_option {
             l!(
                 s,
-                "if let ::std::option::Option::Some(t) = &self.{} {{
+                "if let Option::Some(t) = &self.{} {{
                     s.field(d+1, \"{}\");
                     t.ser_ron(d+1, s);
                     s.conl();
@@ -126,14 +126,14 @@ pub fn derive_de_ron_named(
                     val = format!("\"{}\".to_string()", val)
                 }
                 if field.ty.is_option {
-                    val = format!("::std::option::Option::Some({})", val);
+                    val = format!("Option::Some({})", val);
                 }
                 Some(val)
             } else {
                 if !field.ty.is_option {
                     Some(String::from("::std::default::Default::default()"))
                 } else {
-                    Some(String::from("::std::option::Option::None"))
+                    Some(String::from("Option::None"))
                 }
             }
         } else if let Some(mut v) = field_attr_default_with {
@@ -148,19 +148,19 @@ pub fn derive_de_ron_named(
         if field.ty.is_option {
             unwraps.push(format!(
                 "{{
-                    if let ::std::option::Option::Some(t) = {} {{
+                    if let Option::Some(t) = {} {{
                         t
                     }} else {{
                         {}
                     }}
                 }}",
                 localvar,
-                default_val.unwrap_or_else(|| String::from("::std::option::Option::None"))
+                default_val.unwrap_or_else(|| String::from("Option::None"))
             ));
         } else if container_attr_default || default_val.is_some() {
             unwraps.push(format!(
                 "{{
-                    if let ::std::option::Option::Some(t) = {} {{
+                    if let Option::Some(t) = {} {{
                         t
                     }} else {{
                         {}
@@ -172,7 +172,7 @@ pub fn derive_de_ron_named(
         } else {
             unwraps.push(format!(
                 "{{
-                    if let ::std::option::Option::Some(t) = {} {{
+                    if let Option::Some(t) = {} {{
                         t
                     }} else {{
                         return ::std::result::Result::Err(s.err_nf(\"{}\"))
@@ -190,7 +190,7 @@ pub fn derive_de_ron_named(
     let mut local_lets = String::new();
 
     for local in &local_vars {
-        l!(local_lets, "let mut {} = ::std::option::Option::None;", local)
+        l!(local_lets, "let mut {} = Option::None;", local)
     }
 
     let match_names = if ron_field_names.len() != 0 {
@@ -200,7 +200,7 @@ pub fn derive_de_ron_named(
                 inner,
                 "\"{}\" => {{
                     s.next_colon(i)?;
-                    {} = ::std::option::Option::Some(DeRon::de_ron(s, i)?)
+                    {} = Option::Some(DeRon::de_ron(s, i)?)
                 }},",
                 ron_field_name,
                 local_var
@@ -227,7 +227,7 @@ pub fn derive_de_ron_named(
         "{{
             {}
             s.paren_open(i)?;
-            while let ::std::option::Option::Some(_) = s.next_ident() {{
+            while let Option::Some(_) = s.next_ident() {{
                 {}
                 s.eat_comma_paren(i)?;
             }};


### PR DESCRIPTION
This PR makes the macros in this crate use fully qualified paths, which prevents assumptions about what's in the user's scope. For example, this makes it possible to use `#[derive(nanoserde::SerJson)]` without first writing `use nanoserde::SerJson;`, which allows this crate to be used in other macros (my requirement).

I think I've caught everything, but there are around a thousand lines of (very impressive) manual macros, so it's entirely possible that I've missed a few things!

*By the way, thanks for this crate, it's extremely useful!*