### PR TITLE
Make nanoserde compatible with no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ edition = "2018"
 repository = "https://github.com/not-fl3/nanoserde"
 
 [dependencies]
+hashbrown = "0.12.3"
 nanoserde-derive = { path = "derive", version = "=0.1.18" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ pub struct Property {
 edition = "2018"
 repository = "https://github.com/not-fl3/nanoserde"
 
+[features]
+default = []
+no_std = ["dep:hashbrown"]
+
 [dependencies]
-hashbrown = "0.12.3"
+hashbrown = { version = "0.12.3", optional = true }
 nanoserde-derive = { path = "derive", version = "=0.1.18" }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,3 +1,6 @@
+#![no_std]
+
+extern crate alloc;
 extern crate proc_macro;
 
 #[macro_use]
@@ -118,6 +121,7 @@ pub fn derive_de_json(input: proc_macro::TokenStream) -> proc_macro::TokenStream
     if let Some(proxy) = shared::attrs_proxy(&input.attributes()) {
         return derive_de_json_proxy(&proxy, &input.name());
     }
+
     // ok we have an ident, its either a struct or a enum
     let ts = match &input {
         parse::Data::Struct(struct_) if struct_.named => derive_de_json_struct(struct_),

--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -4,9 +4,13 @@
 //! https://docs.rs/syn/0.15.44/syn/enum.Type.html
 //! https://ziglang.org/documentation/0.5.0/#toc-typeInfo
 
-use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
+use core::iter::Peekable;
 
-use std::iter::Peekable;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use alloc::{format, vec};
+
+use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 
 #[derive(Debug)]
 pub struct Attribute {
@@ -178,10 +182,11 @@ pub fn next_group(source: &mut Peekable<impl Iterator<Item = TokenTree>>) -> Opt
     }
 }
 
-#[allow(dead_code)]
-pub fn debug_current_token(source: &mut Peekable<impl Iterator<Item = TokenTree>>) {
-    println!("{:?}", source.peek());
-}
+// TODO: Replace with no_std equivalent.
+// #[allow(dead_code)]
+// pub fn debug_current_token(source: &mut Peekable<impl Iterator<Item = TokenTree>>) {
+//     println!("{:?}", source.peek());
+// }
 
 fn next_type<T: Iterator<Item = TokenTree>>(mut source: &mut Peekable<T>) -> Option<Type> {
     let group = next_group(&mut source);

--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -182,8 +182,6 @@ pub fn next_group(source: &mut Peekable<impl Iterator<Item = TokenTree>>) -> Opt
     }
 }
 
-// TODO: Replace with no_std equivalent.
-// #[allow(dead_code)]
 // pub fn debug_current_token(source: &mut Peekable<impl Iterator<Item = TokenTree>>) {
 //     println!("{:?}", source.peek());
 // }

--- a/derive/src/serde_bin.rs
+++ b/derive/src/serde_bin.rs
@@ -1,3 +1,6 @@
+use alloc::format;
+use alloc::string::String;
+
 use crate::parse::{Enum, Struct};
 
 use proc_macro::TokenStream;
@@ -19,9 +22,9 @@ pub fn derive_ser_bin_proxy(proxy_type: &str, type_: &str) -> TokenStream {
 pub fn derive_de_bin_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
         "impl DeBin for {} {{
-            fn de_bin(o:&mut usize, d:&[u8]) -> std::result::Result<Self, nanoserde::DeBinErr> {{
+            fn de_bin(o:&mut usize, d:&[u8]) -> core::result::Result<Self, nanoserde::DeBinErr> {{
                 let proxy: {} = DeBin::de_bin(o, d)?;
-                std::result::Result::Ok(Into::into(&proxy))
+                core::result::Result::Ok(Into::into(&proxy))
             }}
         }}",
         type_, proxy_type
@@ -105,8 +108,8 @@ pub fn derive_de_bin_struct(struct_: &Struct) -> TokenStream {
 
     format!(
         "impl DeBin for {} {{
-            fn de_bin(o:&mut usize, d:&[u8]) -> std::result::Result<Self, nanoserde::DeBinErr> {{
-                std::result::Result::Ok(Self {{
+            fn de_bin(o:&mut usize, d:&[u8]) -> core::result::Result<Self, nanoserde::DeBinErr> {{
+                core::result::Result::Ok(Self {{
                     {}
                 }})
             }}
@@ -133,8 +136,8 @@ pub fn derive_de_bin_struct_unnamed(struct_: &Struct) -> TokenStream {
 
     format!(
         "impl DeBin for {} {{
-            fn de_bin(o:&mut usize, d:&[u8]) -> std::result::Result<Self, nanoserde::DeBinErr> {{
-                std::result::Result::Ok(Self {{
+            fn de_bin(o:&mut usize, d:&[u8]) -> core::result::Result<Self, nanoserde::DeBinErr> {{
+                core::result::Result::Ok(Self {{
                     {}
                 }})
             }}
@@ -231,11 +234,11 @@ pub fn derive_de_bin_enum(enum_: &Enum) -> TokenStream {
 
     format!(
         "impl  DeBin for {} {{
-            fn de_bin(o:&mut usize, d:&[u8]) -> std::result::Result<Self, nanoserde::DeBinErr> {{
+            fn de_bin(o:&mut usize, d:&[u8]) -> core::result::Result<Self, nanoserde::DeBinErr> {{
                 let id: u16 = DeBin::de_bin(o,d)?;
                 Ok(match id {{
                     {}
-                    _ => return std::result::Result::Err(nanoserde::DeBinErr{{o:*o, l:0, s:d.len()}})
+                    _ => return core::result::Result::Err(nanoserde::DeBinErr{{o:*o, l:0, s:d.len()}})
                 }})
             }}
         }}", enum_.name, r)

--- a/derive/src/serde_ron.rs
+++ b/derive/src/serde_ron.rs
@@ -1,3 +1,7 @@
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::{vec, vec::Vec};
+
 use crate::parse::{Attribute, Enum, Field, Struct};
 
 use proc_macro::TokenStream;
@@ -21,9 +25,9 @@ pub fn derive_ser_ron_proxy(proxy_type: &str, type_: &str) -> TokenStream {
 pub fn derive_de_ron_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
         "impl DeRon for {} {{
-            fn de_ron(_s: &mut nanoserde::DeRonState, i: &mut std::str::Chars) -> std::result::Result<Self, nanoserde::DeRonErr> {{
+            fn de_ron(_s: &mut nanoserde::DeRonState, i: &mut core::str::Chars) -> core::result::Result<Self, nanoserde::DeRonErr> {{
                 let proxy: {} = DeRon::deserialize_ron(i)?;
-                std::result::Result::Ok(Into::into(&proxy))
+                core::result::Result::Ok(Into::into(&proxy))
             }}
         }}",
         type_, proxy_type
@@ -209,7 +213,7 @@ pub fn derive_de_ron_named(
         format!(
             "match s.identbuf.as_ref() {{
                 {}
-                _ => return std::result::Result::Err(s.err_exp(&s.identbuf))
+                _ => return core::result::Result::Err(s.err_exp(&s.identbuf))
             }}",
             inner
         )
@@ -245,8 +249,8 @@ pub fn derive_de_ron_struct(struct_: &Struct) -> TokenStream {
 
     format!(
         "impl DeRon for {} {{
-            fn de_ron(s: &mut nanoserde::DeRonState, i: &mut std::str::Chars) -> std::result::Result<Self,nanoserde::DeRonErr> {{
-                std::result::Result::Ok({})
+            fn de_ron(s: &mut nanoserde::DeRonState, i: &mut core::str::Chars) -> core::result::Result<Self,nanoserde::DeRonErr> {{
+                core::result::Result::Ok({})
             }}
         }}", struct_.name, body)
     .parse()
@@ -269,11 +273,11 @@ pub fn derive_de_ron_struct_unnamed(struct_: &Struct) -> TokenStream {
 
     format! ("
         impl DeRon for {} {{
-            fn de_ron(s: &mut nanoserde::DeRonState, i: &mut std::str::Chars) -> std::result::Result<Self,nanoserde::DeRonErr> {{
+            fn de_ron(s: &mut nanoserde::DeRonState, i: &mut core::str::Chars) -> core::result::Result<Self,nanoserde::DeRonErr> {{
                 s.paren_open(i)?;
                 let r = Self({});
                 s.paren_close(i)?;
-                std::result::Result::Ok(r)
+                core::result::Result::Ok(r)
             }}
         }}",struct_.name, body
     ).parse().unwrap()
@@ -421,12 +425,12 @@ pub fn derive_de_ron_enum(enum_: &Enum) -> TokenStream {
 
     format! ("
         impl DeRon for {} {{
-            fn de_ron(s: &mut nanoserde::DeRonState, i: &mut std::str::Chars) -> std::result::Result<Self,nanoserde::DeRonErr> {{
+            fn de_ron(s: &mut nanoserde::DeRonState, i: &mut core::str::Chars) -> core::result::Result<Self,nanoserde::DeRonErr> {{
                 // we are expecting an identifier
                 s.ident(i)?;
-                std::result::Result::Ok(match s.identbuf.as_ref() {{
+                core::result::Result::Ok(match s.identbuf.as_ref() {{
                     {}
-                    _ => return std::result::Result::Err(s.err_enum(&s.identbuf))
+                    _ => return core::result::Result::Err(s.err_enum(&s.identbuf))
                 }})
             }}
         }}", enum_.name, body).parse().unwrap()

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -1,10 +1,12 @@
+use alloc::string::String;
+
 macro_rules! l {
     ($target:ident, $line:expr) => {
-        $target.push_str($line);
+        $target.push_str($line)
     };
 
     ($target:ident, $line:expr, $($param:expr),*) => {
-        $target.push_str(&format!($line, $($param,)*));
+        $target.push_str(&::alloc::format!($line, $($param,)*))
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,13 @@
 //! `nanoserde` supports some serialization customisation with `#[nserde()]` attributes.
 //! For `#[nserde(..)]` supported attributes for each format check [Features support matrix](https://github.com/not-fl3/nanoserde#features-support-matrix)
 
+#![no_std]
+// Possibly stable in 1.65.
+// See: https://github.com/rust-lang/rust/pull/99917
+#![feature(error_in_core)]
+
+extern crate alloc;
+
 pub use nanoserde_derive::*;
 
 mod serde_bin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@
 //! `nanoserde` supports some serialization customisation with `#[nserde()]` attributes.
 //! For `#[nserde(..)]` supported attributes for each format check [Features support matrix](https://github.com/not-fl3/nanoserde#features-support-matrix)
 
-#![no_std]
+#![cfg_attr(features = "no_std", no_std)]
 // Possibly stable in 1.65.
 // See: https://github.com/rust-lang/rust/pull/99917
-#![feature(error_in_core)]
+#![cfg_attr(features = "no_std", feature(error_in_core))]
 
 extern crate alloc;
 

--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -5,7 +5,11 @@ use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
+#[cfg(features = "no_std")]
 use hashbrown::HashMap;
+
+#[cfg(not(features = "no_std"))]
+use std::collections::HashMap;
 
 /// A trait for objects that can be serialized to binary.
 pub trait SerBin {
@@ -78,7 +82,11 @@ impl core::fmt::Display for DeBinErr {
     }
 }
 
+#[cfg(features = "no_std")]
 impl core::error::Error for DeBinErr {}
+
+#[cfg(not(features = "no_std"))]
+impl std::error::Error for DeBinErr {}
 
 macro_rules! impl_ser_de_bin_for {
     ($ty:ident) => {

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -6,7 +6,11 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
+#[cfg(features = "no_std")]
 use hashbrown::HashMap;
+
+#[cfg(not(features = "no_std"))]
+use std::collections::HashMap;
 
 /// The internal state of a JSON serialization.
 pub struct SerJsonState {
@@ -162,7 +166,11 @@ impl core::fmt::Display for DeJsonErr {
     }
 }
 
+#[cfg(features = "no_std")]
 impl core::error::Error for DeJsonErr {}
+
+#[cfg(not(features = "no_std"))]
+impl std::error::Error for DeJsonErr {}
 
 impl DeJsonState {
     pub fn next(&mut self, i: &mut Chars) {

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -1,6 +1,12 @@
-use std::collections::HashMap;
-use std::hash::Hash;
-use std::str::Chars;
+use core::hash::Hash;
+use core::str::Chars;
+
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use hashbrown::HashMap;
 
 /// The internal state of a JSON serialization.
 pub struct SerJsonState {
@@ -138,8 +144,8 @@ pub struct DeJsonErr {
     pub col: usize,
 }
 
-impl std::fmt::Debug for DeJsonErr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DeJsonErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "Json Deserialize error: {}, line:{} col:{}",
@@ -150,13 +156,13 @@ impl std::fmt::Debug for DeJsonErr {
     }
 }
 
-impl std::fmt::Display for DeJsonErr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(self, f)
+impl core::fmt::Display for DeJsonErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self, f)
     }
 }
 
-impl std::error::Error for DeJsonErr {}
+impl core::error::Error for DeJsonErr {}
 
 impl DeJsonState {
     pub fn next(&mut self, i: &mut Chars) {
@@ -315,7 +321,7 @@ impl DeJsonState {
     pub fn next_str(&mut self) -> Option<()> {
         if let DeJsonTok::Str = &mut self.tok {
             //let mut s = String::new();
-            //std::mem::swap(&mut s, name);
+            //core::mem::swap(&mut s, name);
             Some(())
         } else {
             None
@@ -403,7 +409,7 @@ impl DeJsonState {
     pub fn as_string(&mut self) -> Result<String, DeJsonErr> {
         if let DeJsonTok::Str = &mut self.tok {
             let mut val = String::new();
-            std::mem::swap(&mut val, &mut self.strbuf);
+            core::mem::swap(&mut val, &mut self.strbuf);
             return Ok(val);
         }
         Err(self.err_token("string"))
@@ -625,9 +631,9 @@ impl DeJsonState {
             // like `\u+123` and such which makes it less attractive.
             (0..4).try_fold(0u16, |acc, _| {
                 let n = match de.cur {
-                    '0'..='9' => (de.cur as u16 - '0' as u16),
-                    'a'..='f' => (de.cur as u16 - 'a' as u16) + 10,
-                    'A'..='F' => (de.cur as u16 - 'A' as u16) + 10,
+                    '0'..='9' => de.cur as u16 - '0' as u16,
+                    'a'..='f' => de.cur as u16 - 'a' as u16 + 10,
+                    'A'..='F' => de.cur as u16 - 'A' as u16 + 10,
                     _ => return None,
                 };
                 de.next(i);
@@ -693,15 +699,15 @@ macro_rules! impl_ser_de_json_float {
     };
 }
 
-impl_ser_de_json_unsigned!(usize, std::u64::MAX);
-impl_ser_de_json_unsigned!(u64, std::u64::MAX);
-impl_ser_de_json_unsigned!(u32, std::u32::MAX);
-impl_ser_de_json_unsigned!(u16, std::u16::MAX);
-impl_ser_de_json_unsigned!(u8, std::u8::MAX);
-impl_ser_de_json_signed!(i64, std::i64::MIN, std::i64::MAX);
-impl_ser_de_json_signed!(i32, std::i64::MIN, std::i64::MAX);
-impl_ser_de_json_signed!(i16, std::i64::MIN, std::i64::MAX);
-impl_ser_de_json_signed!(i8, std::i64::MIN, std::i8::MAX);
+impl_ser_de_json_unsigned!(usize, core::u64::MAX);
+impl_ser_de_json_unsigned!(u64, core::u64::MAX);
+impl_ser_de_json_unsigned!(u32, core::u32::MAX);
+impl_ser_de_json_unsigned!(u16, core::u16::MAX);
+impl_ser_de_json_unsigned!(u8, core::u8::MAX);
+impl_ser_de_json_signed!(i64, core::i64::MIN, core::i64::MAX);
+impl_ser_de_json_signed!(i32, core::i64::MIN, core::i64::MAX);
+impl_ser_de_json_signed!(i16, core::i64::MIN, core::i64::MAX);
+impl_ser_de_json_signed!(i8, core::i64::MIN, core::i8::MAX);
 impl_ser_de_json_float!(f64);
 impl_ser_de_json_float!(f32);
 
@@ -774,7 +780,7 @@ impl SerJson for String {
                 '\r' => s.out += "\\r",
                 '\t' => s.out += "\\t",
                 _ if c.is_ascii_control() => {
-                    use std::fmt::Write as _;
+                    use core::fmt::Write as _;
                     let _ = write!(s.out, "\\u{:04x}", c as u32);
                 }
                 '\\' => s.out += "\\\\",
@@ -854,8 +860,8 @@ where
 {
     fn de_json(o: &mut DeJsonState, d: &mut Chars) -> Result<Self, DeJsonErr> {
         unsafe {
-            let mut to = std::mem::MaybeUninit::<[T; N]>::uninit();
-            let top: *mut T = std::mem::transmute(&mut to);
+            let mut to = core::mem::MaybeUninit::<[T; N]>::uninit();
+            let top: *mut T = core::mem::transmute(&mut to);
             de_json_array_impl_inner(top, N, o, d)?;
             Ok(to.assume_init())
         }

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -6,7 +6,11 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
+#[cfg(features = "no_std")]
 use hashbrown::HashMap;
+
+#[cfg(not(features = "no_std"))]
+use std::collections::HashMap;
 
 /// The internal state of a RON serialization.
 pub struct SerRonState {
@@ -159,8 +163,11 @@ impl core::fmt::Display for DeRonErr {
     }
 }
 
-// NOTE: core::error::Error requires nightly for now
+#[cfg(features = "no_std")]
 impl core::error::Error for DeRonErr {}
+
+#[cfg(not(features = "no_std"))]
+impl std::error::Error for DeRonErr {}
 
 impl DeRonState {
     pub fn next(&mut self, i: &mut Chars) {

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -4,7 +4,11 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::{vec, vec::Vec};
 
+#[cfg(features = "no_std")]
 use hashbrown::HashMap;
+
+#[cfg(not(features = "no_std"))]
+use std::collections::HashMap;
 
 /// A parser for TOML string values.
 ///
@@ -144,7 +148,11 @@ impl Out {
     }
 }
 
+#[cfg(features = "no_std")]
 impl core::error::Error for TomlErr {}
+
+#[cfg(not(features = "no_std"))]
+impl std::error::Error for TomlErr {}
 
 impl TomlParser {
     /// Parse a TOML string.

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -1,5 +1,10 @@
-use std::collections::HashMap;
-use std::str::Chars;
+use core::str::Chars;
+
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::{vec, vec::Vec};
+
+use hashbrown::HashMap;
 
 /// A parser for TOML string values.
 ///
@@ -47,7 +52,7 @@ pub enum Toml {
     SimpleArray(Vec<Toml>),
 }
 
-impl std::ops::Index<usize> for Toml {
+impl core::ops::Index<usize> for Toml {
     type Output = HashMap<String, Toml>;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -87,8 +92,8 @@ pub struct TomlErr {
     pub col: usize,
 }
 
-impl std::fmt::Debug for TomlErr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for TomlErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "Toml error: {}, line:{} col:{}",
@@ -99,9 +104,9 @@ impl std::fmt::Debug for TomlErr {
     }
 }
 
-impl std::fmt::Display for TomlErr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(self, f)
+impl core::fmt::Display for TomlErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self, f)
     }
 }
 
@@ -139,7 +144,7 @@ impl Out {
     }
 }
 
-impl std::error::Error for TomlErr {}
+impl core::error::Error for TomlErr {}
 
 impl TomlParser {
     /// Parse a TOML string.
@@ -242,11 +247,11 @@ impl TomlParser {
             TomlTok::I64(v) => Ok(Toml::Num(v as f64)),
             TomlTok::F64(v) => Ok(Toml::Num(v as f64)),
             TomlTok::Bool(v) => Ok(Toml::Bool(v)),
-            TomlTok::Nan(v) => Ok(Toml::Num(if v { -std::f64::NAN } else { std::f64::NAN })),
+            TomlTok::Nan(v) => Ok(Toml::Num(if v { -core::f64::NAN } else { core::f64::NAN })),
             TomlTok::Inf(v) => Ok(Toml::Num(if v {
-                -std::f64::INFINITY
+                -core::f64::INFINITY
             } else {
-                std::f64::INFINITY
+                core::f64::INFINITY
             })),
             TomlTok::Date(v) => Ok(Toml::Date(v)),
             _ => Err(self.err_token(tok)),

--- a/tests/bin.rs
+++ b/tests/bin.rs
@@ -116,7 +116,7 @@ fn tuple_struct() {
     #[derive(DeBin, SerBin, PartialEq)]
     pub struct Vec2(pub(crate) f32, pub(crate) f32);
 
-    let test = Test(0, 1, "asd".to_string(), 2., [3_u64 ; 100]);
+    let test = Test(0, 1, "asd".to_string(), 2., [3_u64; 100]);
     let bytes = SerBin::serialize_bin(&test);
 
     let test_deserialized = DeBin::deserialize_bin(&bytes).unwrap();

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,5 +1,7 @@
 use nanoserde::{DeJson, SerJson};
 
+use std::collections::HashMap;
+
 #[test]
 fn de() {
     #[derive(DeJson)]
@@ -284,11 +286,11 @@ fn one_field() {
 fn one_field_map() {
     #[derive(DeJson, SerJson, PartialEq)]
     pub struct OneField {
-        field: hashbrown::HashMap<String, f32>,
+        field: HashMap<String, f32>,
     }
 
     let test = OneField {
-        field: hashbrown::HashMap::new(),
+        field: HashMap::new(),
     };
     let bytes = SerJson::serialize_json(&test);
     let test_deserialized = DeJson::deserialize_json(&bytes).unwrap();
@@ -355,7 +357,7 @@ fn path_type() {
 fn hashmaps() {
     #[derive(DeJson)]
     struct Foo {
-        map: hashbrown::HashMap<String, i32>,
+        map: HashMap<String, i32>,
     }
 
     let json = r#"{

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -284,11 +284,11 @@ fn one_field() {
 fn one_field_map() {
     #[derive(DeJson, SerJson, PartialEq)]
     pub struct OneField {
-        field: std::collections::HashMap<String, f32>,
+        field: hashbrown::HashMap<String, f32>,
     }
 
     let test = OneField {
-        field: std::collections::HashMap::new(),
+        field: hashbrown::HashMap::new(),
     };
     let bytes = SerJson::serialize_json(&test);
     let test_deserialized = DeJson::deserialize_json(&bytes).unwrap();
@@ -355,7 +355,7 @@ fn path_type() {
 fn hashmaps() {
     #[derive(DeJson)]
     struct Foo {
-        map: std::collections::HashMap<String, i32>,
+        map: hashbrown::HashMap<String, i32>,
     }
 
     let json = r#"{

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -163,11 +163,11 @@ fn one_field() {
 fn one_field_map() {
     #[derive(DeRon, SerRon, PartialEq)]
     pub struct OneField {
-        field: std::collections::HashMap<String, f32>,
+        field: hashbrown::HashMap<String, f32>,
     }
 
     let test = OneField {
-        field: std::collections::HashMap::new(),
+        field: hashbrown::HashMap::new(),
     };
     let bytes = SerRon::serialize_ron(&test);
     let test_deserialized = DeRon::deserialize_ron(&bytes).unwrap();
@@ -234,7 +234,7 @@ fn path_type() {
 fn hashmaps() {
     #[derive(DeRon)]
     struct Foo {
-        map: std::collections::HashMap<String, i32>,
+        map: hashbrown::HashMap<String, i32>,
     }
 
     let ron = r#"(

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -1,5 +1,7 @@
 use nanoserde::{DeRon, SerRon};
 
+use std::collections::HashMap;
+
 #[test]
 fn ron_de() {
     #[derive(DeRon)]
@@ -163,11 +165,11 @@ fn one_field() {
 fn one_field_map() {
     #[derive(DeRon, SerRon, PartialEq)]
     pub struct OneField {
-        field: hashbrown::HashMap<String, f32>,
+        field: HashMap<String, f32>,
     }
 
     let test = OneField {
-        field: hashbrown::HashMap::new(),
+        field: HashMap::new(),
     };
     let bytes = SerRon::serialize_ron(&test);
     let test_deserialized = DeRon::deserialize_ron(&bytes).unwrap();
@@ -234,7 +236,7 @@ fn path_type() {
 fn hashmaps() {
     #[derive(DeRon)]
     struct Foo {
-        map: hashbrown::HashMap<String, i32>,
+        map: HashMap<String, i32>,
     }
 
     let ron = r#"(

--- a/tests/ser_de.rs
+++ b/tests/ser_de.rs
@@ -8,10 +8,10 @@ fn ser_de() {
         pub b: f32,
         c: Option<String>,
         d: Option<String>,
-        e: Option<std::collections::HashMap<String, String>>,
+        e: Option<hashbrown::HashMap<String, String>>,
     }
 
-    let mut map = std::collections::HashMap::new();
+    let mut map = hashbrown::HashMap::new();
     map.insert("a".to_string(), "b".to_string());
 
     let test: Test = Test {

--- a/tests/ser_de.rs
+++ b/tests/ser_de.rs
@@ -1,5 +1,7 @@
 use nanoserde::{DeBin, DeJson, SerBin, SerJson};
 
+use std::collections::HashMap;
+
 #[test]
 fn ser_de() {
     #[derive(DeBin, SerBin, DeJson, SerJson, PartialEq)]
@@ -8,10 +10,10 @@ fn ser_de() {
         pub b: f32,
         c: Option<String>,
         d: Option<String>,
-        e: Option<hashbrown::HashMap<String, String>>,
+        e: Option<HashMap<String, String>>,
     }
 
-    let mut map = hashbrown::HashMap::new();
+    let mut map = HashMap::new();
     map.insert("a".to_string(), "b".to_string());
 
     let test: Test = Test {


### PR DESCRIPTION
This makes `nanoserde` fully `no_std`. Currently marked as draft since `core::error::Error` will most likely become stable in rustc 1.65

Objective of this radical change is mostly console support (tested on PS5 & Switch) and some embedded environments like arduino boards.