### PR TITLE
add fixed-len array and i8 serde impls (with test)

### DIFF
--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -127,6 +127,7 @@ impl_ser_de_bin_for!(u32);
 impl_ser_de_bin_for!(i32);
 impl_ser_de_bin_for!(u16);
 impl_ser_de_bin_for!(i16);
+impl_ser_de_bin_for!(i8);
 
 impl SerBin for usize {
     fn ser_bin(&self, s: &mut Vec<u8>) {
@@ -380,6 +381,16 @@ where
         for item in self {
             item.ser_bin(s);
         }
+    }
+}
+
+impl<T, const N: usize> SerBin for [T; N]
+where
+    T: SerBin,
+{
+    #[inline(always)]
+    fn ser_bin(&self, s: &mut Vec<u8>) {
+        self.as_slice().ser_bin(s)
     }
 }
 

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -974,6 +974,16 @@ where
     }
 }
 
+impl<T, const N: usize> SerJson for [T; N]
+where
+    T: SerJson,
+{
+    #[inline(always)]
+    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+        self.as_slice().ser_json(d, s)
+    }
+}
+
 impl<T, const N: usize> DeJson for [T; N]
 where
     T: DeJson,

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -1011,6 +1011,16 @@ where
     }
 }
 
+impl<T, const N: usize> SerRon for [T; N]
+where
+    T: SerRon,
+{
+    #[inline(always)]
+    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+        self.as_slice().ser_ron(d, s)
+    }
+}
+
 unsafe fn de_ron_array_impl_inner<T>(
     top: *mut T,
     count: usize,

--- a/tests/ser_de.rs
+++ b/tests/ser_de.rs
@@ -11,6 +11,7 @@ fn ser_de() {
         c: Option<String>,
         d: Option<String>,
         e: Option<HashMap<String, String>>,
+        f: Option<([u32; 4], String)>,
     }
 
     let mut map = HashMap::new();
@@ -22,6 +23,7 @@ fn ser_de() {
         c: Some("asd".to_string()),
         d: None,
         e: Some(map),
+        f: Some(([1, 2, 3, 4], "tuple".to_string())),
     };
 
     let bytes = SerBin::serialize_bin(&test);


### PR DESCRIPTION
Noticed while adding nanoserde to the rust serialization benchmark repo that fixed-length arrays and `i8`s were not  being handled. 