### PR TITLE
put macros and traits of each type behind individual feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,11 @@ edition = "2018"
 repository = "https://github.com/not-fl3/nanoserde"
 
 [features]
-default = []
+default = ["json", "binary", "ron", "toml"]
+json = ["nanoserde-derive/json"]
+binary = ["nanoserde-derive/binary"]
+ron = ["nanoserde-derive/ron"]
+toml = []
 no_std = ["dep:hashbrown"]
 
 [dependencies]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -11,6 +11,10 @@ proc-macro = true
 
 [features]
 default = []
+json = []
+binary = []
+ron = []
+toml = []
 no_std = ["dep:hashbrown"]
 
 [dependencies]

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -6,18 +6,24 @@ extern crate proc_macro;
 #[macro_use]
 mod shared;
 
+#[cfg(feature = "binary")]
 mod serde_bin;
+#[cfg(feature = "binary")]
 use crate::serde_bin::*;
 
+#[cfg(feature = "ron")]
 mod serde_ron;
+#[cfg(feature = "ron")]
 use crate::serde_ron::*;
 
+#[cfg(feature = "json")]
 mod serde_json;
+#[cfg(feature = "json")]
+use crate::serde_json::*;
 
 mod parse;
 
-use crate::serde_json::*;
-
+#[cfg(feature = "binary")]
 #[proc_macro_derive(SerBin, attributes(nserde))]
 pub fn derive_ser_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
@@ -37,6 +43,7 @@ pub fn derive_ser_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream
     ts
 }
 
+#[cfg(feature = "binary")]
 #[proc_macro_derive(DeBin, attributes(nserde))]
 pub fn derive_de_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
@@ -57,6 +64,7 @@ pub fn derive_de_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
     ts
 }
 
+#[cfg(feature = "ron")]
 #[proc_macro_derive(SerRon, attributes(nserde))]
 pub fn derive_ser_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
@@ -76,6 +84,7 @@ pub fn derive_ser_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream
     ts
 }
 
+#[cfg(feature = "ron")]
 #[proc_macro_derive(DeRon, attributes(nserde))]
 pub fn derive_de_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
@@ -95,6 +104,7 @@ pub fn derive_de_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
     ts
 }
 
+#[cfg(feature = "json")]
 #[proc_macro_derive(SerJson, attributes(nserde))]
 pub fn derive_ser_json(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
@@ -114,6 +124,7 @@ pub fn derive_ser_json(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
     ts
 }
 
+#[cfg(feature = "json")]
 #[proc_macro_derive(DeJson, attributes(nserde))]
 pub fn derive_de_json(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@
 //!
 //! Data serialization library with zero dependencies. No more syn/proc_macro2/quote in the build tree!
 //!
-//! `nanoserde` also almost do not use any generics, so build size is not going to be bloated with monomorphizated code.
-//!
 //! The main difference with "serde" and the reason why "nanoserde" is possible: there is no intermediate data model
 //! For each serialisation datatype there is a special macro.
 //!
@@ -26,14 +24,22 @@ extern crate alloc;
 
 pub use nanoserde_derive::*;
 
+#[cfg(feature = "binary")]
 mod serde_bin;
+#[cfg(feature = "binary")]
 pub use crate::serde_bin::*;
 
+#[cfg(feature = "ron")]
 mod serde_ron;
+#[cfg(feature = "ron")]
 pub use crate::serde_ron::*;
 
+#[cfg(feature = "json")]
 mod serde_json;
+#[cfg(feature = "json")]
 pub use crate::serde_json::*;
 
+#[cfg(feature = "toml")]
 mod toml;
+#[cfg(feature = "toml")]
 pub use crate::toml::*;

--- a/tests/bin.rs
+++ b/tests/bin.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "binary")]
 use std::collections::{BTreeSet, HashMap, HashSet, LinkedList};
 
 use nanoserde::{DeBin, SerBin};

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "json")]
 use nanoserde::{DeJson, SerJson};
 
 use std::collections::{BTreeSet, HashMap, HashSet, LinkedList};

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "ron")]
 use nanoserde::{DeRon, SerRon};
 
 use std::collections::{BTreeSet, HashMap, HashSet, LinkedList};

--- a/tests/ser_de.rs
+++ b/tests/ser_de.rs
@@ -1,3 +1,4 @@
+#![cfg(all(feature = "binary", feature = "json"))]
 use nanoserde::{DeBin, DeJson, SerBin, SerJson};
 
 use std::collections::HashMap;

--- a/tests/toml.rs
+++ b/tests/toml.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "toml")]
 use nanoserde::TomlParser;
 
 #[test]


### PR DESCRIPTION
Looking at how it affects compile times to split the individual serde types up, so you dont have to build `SerJson` to use `SerBin`, for example