### PR TITLE
add serialization of unit type

### DIFF
--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -410,6 +410,20 @@ where
     }
 }
 
+impl SerBin for () {
+    #[inline(always)]
+    fn ser_bin(&self, _s: &mut Vec<u8>) {
+        // do nothing
+    }
+}
+
+impl DeBin for () {
+    #[inline(always)]
+    fn de_bin(_o: &mut usize, _d: &[u8]) -> Result<Self, DeBinErr> {
+        Ok(())
+    }
+}
+
 impl<A, B> SerBin for (A, B)
 where
     A: SerBin,

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -748,15 +748,18 @@ where
 
 impl SerJson for () {
     fn ser_json(&self, _d: usize, s: &mut SerJsonState) {
-        s.out.push_str("")
+        s.out.push_str("null")
     }
 }
 
 impl DeJson for () {
     fn de_json(s: &mut DeJsonState, i: &mut Chars) -> Result<(), DeJsonErr> {
-        // skip ""
-        s.next_tok(i)?;
-        return Ok(());
+        if let DeJsonTok::Null = s.tok {
+            s.next_tok(i)?;
+            return Ok(());
+        } else {
+            return Err(s.err_token("null"));
+        }
     }
 }
 

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -1062,6 +1062,20 @@ where
     t
 }
 
+impl SerRon for () {
+    fn ser_ron(&self, _d: usize, s: &mut SerRonState) {
+        s.out.push_str("()");
+    }
+}
+
+impl DeRon for () {
+    fn de_ron(s: &mut DeRonState, i: &mut Chars) -> Result<(), DeRonErr> {
+        s.paren_open(i)?;
+        s.paren_close(i)?;
+        Ok(())
+    }
+}
+
 impl<A, B> SerRon for (A, B)
 where
     A: SerRon,

--- a/tests/ser_de.rs
+++ b/tests/ser_de.rs
@@ -12,6 +12,7 @@ fn ser_de() {
         d: Option<String>,
         e: Option<HashMap<String, String>>,
         f: Option<([u32; 4], String)>,
+        g: (),
     }
 
     let mut map = HashMap::new();
@@ -24,6 +25,7 @@ fn ser_de() {
         d: None,
         e: Some(map),
         f: Some(([1, 2, 3, 4], "tuple".to_string())),
+        g: (),
     };
 
     let bytes = SerBin::serialize_bin(&test);


### PR DESCRIPTION
Adding serde of unit type to ron and bin, and updating the json version to output valid json (and also matching [serde's behavior](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=d641466cd567ad9bc597ea5cd80e09e2)). Demonstrated with a test that unit type serde was not working correctly in json previously.