### PR TITLE
add with_capacity initialization during deser for the collections

### DIFF
--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -248,7 +248,7 @@ where
 {
     fn de_bin(o: &mut usize, d: &[u8]) -> Result<Vec<T>, DeBinErr> {
         let len: usize = DeBin::de_bin(o, d)?;
-        let mut out = Vec::new();
+        let mut out = Vec::with_capacity(len);
         for _ in 0..len {
             out.push(DeBin::de_bin(o, d)?)
         }
@@ -302,7 +302,7 @@ where
 {
     fn de_bin(o: &mut usize, d: &[u8]) -> Result<HashSet<T>, DeBinErr> {
         let len: usize = DeBin::de_bin(o, d)?;
-        let mut out = HashSet::new();
+        let mut out = HashSet::with_capacity(len);
         for _ in 0..len {
             out.insert(DeBin::de_bin(o, d)?);
         }
@@ -527,7 +527,7 @@ where
 {
     fn de_bin(o: &mut usize, d: &[u8]) -> Result<Self, DeBinErr> {
         let len: usize = DeBin::de_bin(o, d)?;
-        let mut h = HashMap::new();
+        let mut h = HashMap::with_capacity(len);
         for _ in 0..len {
             let k = DeBin::de_bin(o, d)?;
             let v = DeBin::de_bin(o, d)?;


### PR DESCRIPTION
This gives large performance improvements for collection deserialization speed. These results are from the [rust_serialization_benchmark](https://github.com/djkoloski/rust_serialization_benchmark) crate, with a run against v0.1.33 first and this branch afterwards. The mk48 test in particular was ~30% faster on deserialization.

```
log/nanoserde/serialize time:   [169.86 µs 170.39 µs 171.12 µs]
                        change: [-4.1572% -3.8132% -3.4412%] (p = 0.00 < 0.05)
                        Performance has improved.
log/nanoserde/deserialize
                        time:   [1.8331 ms 1.8341 ms 1.8354 ms]
                        change: [-8.1580% -8.0591% -7.9574%] (p = 0.00 < 0.05)
                        Performance has improved.

mesh/nanoserde/serialize
                        time:   [1.1217 ms 1.1354 ms 1.1511 ms]
                        change: [-18.783% -17.201% -15.571%] (p = 0.00 < 0.05)
                        Performance has improved.
mesh/nanoserde/deserialize
                        time:   [643.65 µs 644.72 µs 646.05 µs]
                        change: [-17.091% -16.834% -16.596%] (p = 0.00 < 0.05)
                        Performance has improved.

minecraft_savedata/nanoserde/serialize
                        time:   [218.12 µs 218.29 µs 218.51 µs]
                        change: [-0.8400% -0.6348% -0.4279%] (p = 0.00 < 0.05)
                        Change within noise threshold.
minecraft_savedata/nanoserde/deserialize
                        time:   [1.6389 ms 1.6468 ms 1.6551 ms]
                        change: [-16.742% -16.483% -16.199%] (p = 0.00 < 0.05)
                        Performance has improved.

mk48/nanoserde/serialize
                        time:   [881.43 µs 885.42 µs 889.92 µs]
                        change: [-3.3084% -2.9239% -2.4109%] (p = 0.00 < 0.05)
                        Performance has improved.
mk48/nanoserde/deserialize
                        time:   [2.5251 ms 2.5262 ms 2.5272 ms]
                        change: [-32.383% -32.335% -32.286%] (p = 0.00 < 0.05)
                        Performance has improved.
```