### PR TITLE
array de bin leak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanoserde"
-version = "0.1.34"
+version = "0.1.36"
 authors = ["makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = """

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -561,6 +561,7 @@ fn test_various_escapes() {
 
 // there are only 1024*1024 surrogate pairs, so we can do an exhautive test.
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_surrogate_pairs_exhaustively() {
     for lead in 0xd800..0xdc00 {
         for trail in 0xdc00..0xe000 {

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -383,6 +383,7 @@ fn test_various_escapes() {
 
 // there are only 1024*1024 surrogate pairs, so we can do an exhautive test.
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_surrogate_pairs_exhaustively() {
     for lead in 0xd800..0xdc00 {
         for trail in 0xdc00..0xe000 {


### PR DESCRIPTION
pr to close #79. The primitives for fallible creation of arrays and transmutation of `MaybeUninit` arrays are both unstable still, so doing it manually here. There are now only two unsafe lines, one to `assume_init` each item in case of success, and one to `assume_init` each item which has been successfully deserialized (so it can be dropped) before returning an error.

The `core::array::map` documentation has some concerning looking warnings about poor performance, so maybe would be better to go back to a transmute for that instead of applying `assume_init` in the map like I've done here.