### PR TITLE
Add accessors for all `Toml` variants

### DIFF
--- a/src/toml.rs
+++ b/src/toml.rs
@@ -68,21 +68,59 @@ impl core::ops::Index<usize> for Toml {
 }
 
 impl Toml {
+    /// Get the TOML value as a float
+    ///
+    /// Panics if the TOML value isn't actually a float
     pub fn num(&self) -> f64 {
         match self {
             Toml::Num(num) => *num,
             _ => panic!(),
         }
     }
+    /// Get the TOML value as a string
+    ///
+    /// Panics if the TOML value isn't actually a string
     pub fn str(&self) -> &str {
         match self {
             Toml::Str(string) => string,
             _ => panic!(),
         }
     }
+    /// Get the TOML value as a boolean
+    ///
+    /// Panics if the TOML value isn't actually a boolean
+    pub fn boolean(&self) -> bool {
+        match self {
+            Toml::Bool(boolean) => *boolean,
+            _ => panic!(),
+        }
+    }
+    /// Get the TOML value as a date string
+    ///
+    /// Panics if the TOML value isn't actually a date string.  See
+    /// [the spec](https://toml.io/en/v1.0.0#local-date) for what "date
+    /// string" means.
+    pub fn date(&self) -> String {
+        match self {
+            Toml::Date(date) => date.to_string(),
+            _ => panic!(),
+        }
+    }
+    /// Get the TOML value as a table
+    ///
+    /// Panics if the TOML value isn't actually a table
     pub fn arr(&self) -> &Vec<HashMap<String, Toml>> {
         match self {
             Toml::Array(array) => array,
+            _ => panic!(),
+        }
+    }
+    /// Get the TOML value as an array
+    ///
+    /// Panics if the TOML value isn't actually an array
+    pub fn simple_arr(&self) -> &Vec<Toml> {
+        match self {
+            Toml::SimpleArray(array) => array,
             _ => panic!(),
         }
     }

--- a/tests/toml.rs
+++ b/tests/toml.rs
@@ -1,3 +1,4 @@
+use nanoserde::Toml;
 use nanoserde::TomlParser;
 
 #[test]
@@ -52,4 +53,34 @@ fn key_without_value() {
     "#;
 
     assert!(TomlParser::parse(data).is_err());
+}
+
+#[test]
+fn assert_specific_toml_types() {
+    let data = r#"
+    num = 3.14
+    str = "quoth the raven"
+    simple_arr = [1, 2, 3, 4]
+    boolean = false
+    date = 1979-05-27
+    "#;
+    assert_eq!(TomlParser::parse(data).unwrap()["num"].num(), 3.14);
+    assert_eq!(
+        TomlParser::parse(data).unwrap()["str"].str(),
+        "quoth the raven"
+    );
+    assert_eq!(TomlParser::parse(data).unwrap()["boolean"].boolean(), false);
+    assert_eq!(
+        TomlParser::parse(data).unwrap()["date"].date(),
+        "1979-05-27".to_string()
+    );
+    assert_eq!(
+        TomlParser::parse(data).unwrap()["simple_arr"].simple_arr(),
+        &vec![
+            Toml::Num(1.0),
+            Toml::Num(2.0),
+            Toml::Num(3.0),
+            Toml::Num(4.0)
+        ]
+    );
 }


### PR DESCRIPTION
This allows users to coerce any TOML value into the type they expect it to be.

The test go over all variants except for Toml::Array since I couldn't figure out how to write one (arr = {key = "value"} ought to work, but doesn't).

I also wrote docstrings for all these methods.  I tended toward the language used in the TOML spec, though I fear that it might be confusing since the API uses language that contradicts the spec.