### PR TITLE
add fixes for some clippy lints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,5 +77,28 @@ jobs:
           command: test
       - uses: actions-rs/cargo@v1
         with:
+          command: test
+
+  test_no_std:
+    name: Test No Std
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: ubuntu-latest, target: 'x86_64-unknown-linux-gnu' }
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: ${{ matrix.config.target }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+      - uses: actions-rs/cargo@v1
+        with:
           command: test 
           args: --features "no_std"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ no_std = ["dep:hashbrown"]
 
 [dependencies]
 hashbrown = { version = "0.12.3", optional = true }
-nanoserde-derive = { path = "derive", version = "=0.1.20" }
+nanoserde-derive = { path = "derive", version = "=0.1.21" }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanoserde-derive"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
 edition = "2018"
 description = "Fork of makepad-tinyserde derive without any external dependencies"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(features = "no_std", no_std)]
+#![cfg_attr(feature = "no_std", no_std)]
 
 extern crate alloc;
 extern crate proc_macro;

--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -222,6 +222,7 @@ pub fn derive_de_json_named(name: &str, defaults: bool, fields: &[Field]) -> Tok
 pub fn derive_de_json_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
         "impl DeJson for {} {{
+            #[allow(clippy::ignored_unit_patterns)]
             fn de_json(_s: &mut nanoserde::DeJsonState, i: &mut core::str::Chars) -> core::result::Result<Self, nanoserde::DeJsonErr> {{
                 let proxy: {} = DeJson::deserialize_json(i)?;
                 core::result::Result::Ok(Into::into(&proxy))
@@ -247,6 +248,7 @@ pub fn derive_de_json_struct(struct_: &Struct) -> TokenStream {
 
     format!(
         "impl{} DeJson for {}{} {{
+            #[allow(clippy::ignored_unit_patterns)]
             fn de_json(s: &mut nanoserde::DeJsonState, i: &mut core::str::Chars) -> core::result::Result<Self,
             nanoserde::DeJsonErr> {{
                 core::result::Result::Ok({{ {} }})
@@ -459,6 +461,7 @@ pub fn derive_de_json_enum(enum_: &Enum) -> TokenStream {
 
     let mut r = format!(
         "impl{} DeJson for {}{} {{
+            #[allow(clippy::ignored_unit_patterns)]
             fn de_json(s: &mut nanoserde::DeJsonState, i: &mut core::str::Chars) -> core::result::Result<Self, nanoserde::DeJsonErr> {{
                 match s.tok {{",
         generic_w_bounds, generic_no_bounds, enum_.name,
@@ -592,6 +595,7 @@ pub fn derive_de_json_struct_unnamed(struct_: &Struct) -> TokenStream {
 
     format! ("
         impl{} DeJson for {}{} {{
+            #[allow(clippy::ignored_unit_patterns)]
             fn de_json(s: &mut nanoserde::DeJsonState, i: &mut core::str::Chars) -> core::result::Result<Self,nanoserde::DeJsonErr> {{
                 {}
                 core::result::Result::Ok(r)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@
 //! `nanoserde` supports some serialization customisation with `#[nserde()]` attributes.
 //! For `#[nserde(..)]` supported attributes for each format check [Features support matrix](https://github.com/not-fl3/nanoserde#features-support-matrix)
 
-#![cfg_attr(features = "no_std", no_std)]
+#![cfg_attr(feature = "no_std", no_std)]
 // Possibly stable in 1.65.
 // See: https://github.com/rust-lang/rust/pull/99917
-#![cfg_attr(features = "no_std", feature(error_in_core))]
+#![cfg_attr(feature = "no_std", feature(error_in_core))]
 
 extern crate alloc;
 

--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -543,7 +543,7 @@ where
 
 impl<K, V> DeBin for HashMap<K, V>
 where
-    K: DeBin + std::cmp::Eq + std::hash::Hash,
+    K: DeBin + core::cmp::Eq + Hash,
     V: DeBin,
 {
     fn de_bin(o: &mut usize, d: &[u8]) -> Result<Self, DeBinErr> {

--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -6,10 +6,10 @@ use alloc::collections::{BTreeSet, LinkedList};
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-#[cfg(features = "no_std")]
+#[cfg(feature = "no_std")]
 use hashbrown::{HashMap, HashSet};
 
-#[cfg(not(features = "no_std"))]
+#[cfg(not(feature = "no_std"))]
 use std::collections::{HashMap, HashSet};
 
 /// A trait for objects that can be serialized to binary.
@@ -83,10 +83,10 @@ impl core::fmt::Display for DeBinErr {
     }
 }
 
-#[cfg(features = "no_std")]
+#[cfg(feature = "no_std")]
 impl core::error::Error for DeBinErr {}
 
-#[cfg(not(features = "no_std"))]
+#[cfg(not(feature = "no_std"))]
 impl std::error::Error for DeBinErr {}
 
 macro_rules! impl_ser_de_bin_for {

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -7,10 +7,10 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-#[cfg(features = "no_std")]
+#[cfg(feature = "no_std")]
 use hashbrown::{HashMap, HashSet};
 
-#[cfg(not(features = "no_std"))]
+#[cfg(not(feature = "no_std"))]
 use std::collections::{HashMap, HashSet};
 
 /// The internal state of a JSON serialization.
@@ -167,10 +167,10 @@ impl core::fmt::Display for DeJsonErr {
     }
 }
 
-#[cfg(features = "no_std")]
+#[cfg(feature = "no_std")]
 impl core::error::Error for DeJsonErr {}
 
-#[cfg(not(features = "no_std"))]
+#[cfg(not(feature = "no_std"))]
 impl std::error::Error for DeJsonErr {}
 
 impl DeJsonState {
@@ -756,9 +756,9 @@ impl DeJson for () {
     fn de_json(s: &mut DeJsonState, i: &mut Chars) -> Result<(), DeJsonErr> {
         if let DeJsonTok::Null = s.tok {
             s.next_tok(i)?;
-            return Ok(());
+            Ok(())
         } else {
-            return Err(s.err_token("null"));
+            Err(s.err_token("null"))
         }
     }
 }
@@ -777,7 +777,7 @@ impl DeJson for bool {
     fn de_json(s: &mut DeJsonState, i: &mut Chars) -> Result<bool, DeJsonErr> {
         let val = s.as_bool()?;
         s.next_tok(i)?;
-        return Ok(val);
+        Ok(val)
     }
 }
 
@@ -815,7 +815,7 @@ impl DeJson for String {
     fn de_json(s: &mut DeJsonState, i: &mut Chars) -> Result<String, DeJsonErr> {
         let val = s.as_string()?;
         s.next_tok(i)?;
-        return Ok(val);
+        Ok(val)
     }
 }
 
@@ -825,7 +825,7 @@ where
 {
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('[');
-        if self.len() > 0 {
+        if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
                 s.indent(d + 1);
@@ -862,7 +862,7 @@ where
 {
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('[');
-        if self.len() > 0 {
+        if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
                 s.indent(d + 1);
@@ -899,7 +899,7 @@ where
 {
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('[');
-        if self.len() > 0 {
+        if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
                 s.indent(d + 1);
@@ -936,7 +936,7 @@ where
 {
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('[');
-        if self.len() > 0 {
+        if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
                 s.indent(d + 1);
@@ -1030,7 +1030,7 @@ where
         // https://github.com/rust-lang/rust/issues/61956
         // initializing before block close so that drop will run automatically if err encountered there
         let initialized =
-            unsafe { (&*(&to as *const _ as *const MaybeUninit<_>)).assume_init_read() };
+            unsafe { (*(&to as *const _ as *const MaybeUninit<_>)).assume_init_read() };
         o.block_close(d)?;
 
         Ok(initialized)
@@ -1156,8 +1156,7 @@ where
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('{');
         let len = self.len();
-        let mut index = 0;
-        for (k, v) in self {
+        for (index, (k, v)) in self.iter().enumerate() {
             s.indent(d + 1);
             k.ser_json(d + 1, s);
             s.out.push(':');
@@ -1165,7 +1164,6 @@ where
             if (index + 1) < len {
                 s.conl();
             }
-            index += 1;
         }
         s.indent(d);
         s.out.push('}');

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -825,7 +825,7 @@ where
 {
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('[');
-        if !self.is_empty() {
+        if self.len() > 0 {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
                 s.indent(d + 1);
@@ -862,7 +862,7 @@ where
 {
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('[');
-        if !self.is_empty() {
+        if self.len() > 0 {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
                 s.indent(d + 1);
@@ -899,7 +899,7 @@ where
 {
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('[');
-        if !self.is_empty() {
+        if self.len() > 0 {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
                 s.indent(d + 1);
@@ -936,7 +936,7 @@ where
 {
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('[');
-        if !self.is_empty() {
+        if self.len() > 0 {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
                 s.indent(d + 1);
@@ -1156,7 +1156,8 @@ where
     fn ser_json(&self, d: usize, s: &mut SerJsonState) {
         s.out.push('{');
         let len = self.len();
-        for (index, (k, v)) in self.iter().enumerate() {
+        let mut index = 0;
+        for (k, v) in self {
             s.indent(d + 1);
             k.ser_json(d + 1, s);
             s.out.push(':');
@@ -1164,6 +1165,7 @@ where
             if (index + 1) < len {
                 s.conl();
             }
+            index += 1;
         }
         s.indent(d);
         s.out.push('}');

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -7,10 +7,10 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-#[cfg(features = "no_std")]
+#[cfg(feature = "no_std")]
 use hashbrown::{HashMap, HashSet};
 
-#[cfg(not(features = "no_std"))]
+#[cfg(not(feature = "no_std"))]
 use std::collections::{HashMap, HashSet};
 
 /// The internal state of a RON serialization.
@@ -164,10 +164,10 @@ impl core::fmt::Display for DeRonErr {
     }
 }
 
-#[cfg(features = "no_std")]
+#[cfg(feature = "no_std")]
 impl core::error::Error for DeRonErr {}
 
-#[cfg(not(features = "no_std"))]
+#[cfg(not(feature = "no_std"))]
 impl std::error::Error for DeRonErr {}
 
 impl DeRonState {

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -4,10 +4,10 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::{vec, vec::Vec};
 
-#[cfg(features = "no_std")]
+#[cfg(feature = "no_std")]
 use hashbrown::HashMap;
 
-#[cfg(not(features = "no_std"))]
+#[cfg(not(feature = "no_std"))]
 use std::collections::HashMap;
 
 /// A parser for TOML string values.
@@ -158,7 +158,7 @@ struct Out {
 }
 impl Out {
     fn start_array(&mut self, key: &str) {
-        if self.out.contains_key(key) == false {
+        if !self.out.contains_key(key) {
             self.out.insert(key.to_string(), Toml::Array(vec![]));
         }
 
@@ -186,10 +186,10 @@ impl Out {
     }
 }
 
-#[cfg(features = "no_std")]
+#[cfg(feature = "no_std")]
 impl core::error::Error for TomlErr {}
 
-#[cfg(not(features = "no_std"))]
+#[cfg(not(feature = "no_std"))]
 impl std::error::Error for TomlErr {}
 
 impl TomlParser {
@@ -252,11 +252,11 @@ impl TomlParser {
                 }
             }
             TomlTok::Str(key) | TomlTok::Ident(key) => {
-                self.parse_key_value(&local_scope, key, i, out.out())?
+                self.parse_key_value(local_scope, key, i, out.out())?
             }
             _ => return Err(self.err_token(tok)),
         }
-        return Ok(true);
+        Ok(true)
     }
 
     fn to_val(&mut self, tok: TomlTok, i: &mut Chars) -> Result<Toml, TomlErr> {
@@ -277,7 +277,7 @@ impl TomlParser {
             TomlTok::Str(v) => Ok(Toml::Str(v)),
             TomlTok::U64(v) => Ok(Toml::Num(v as f64)),
             TomlTok::I64(v) => Ok(Toml::Num(v as f64)),
-            TomlTok::F64(v) => Ok(Toml::Num(v as f64)),
+            TomlTok::F64(v) => Ok(Toml::Num(v)),
             TomlTok::Bool(v) => Ok(Toml::Bool(v)),
             TomlTok::Nan(v) => Ok(Toml::Num(if v { -core::f64::NAN } else { core::f64::NAN })),
             TomlTok::Inf(v) => Ok(Toml::Num(if v {
@@ -303,7 +303,7 @@ impl TomlParser {
         }
         let tok = self.next_tok(i)?;
         let val = self.to_val(tok, i)?;
-        let key = if local_scope.len() > 0 {
+        let key = if !local_scope.is_empty() {
             format!("{}.{}", local_scope, key)
         } else {
             key

--- a/tests/bin.rs
+++ b/tests/bin.rs
@@ -1,8 +1,14 @@
 use std::{
     array,
-    collections::{BTreeSet, HashMap, HashSet, LinkedList},
+    collections::{BTreeSet, LinkedList},
     sync::atomic::AtomicBool,
 };
+
+#[cfg(feature = "no_std")]
+use hashbrown::{HashMap, HashSet};
+
+#[cfg(not(feature = "no_std"))]
+use std::collections::{HashMap, HashSet};
 
 use nanoserde::{DeBin, SerBin};
 

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,9 +1,15 @@
 use nanoserde::{DeJson, SerJson};
 
 use std::{
-    collections::{BTreeSet, HashMap, HashSet, LinkedList},
+    collections::{BTreeSet, LinkedList},
     sync::atomic::AtomicBool,
 };
+
+#[cfg(feature = "no_std")]
+use hashbrown::{HashMap, HashSet};
+
+#[cfg(not(feature = "no_std"))]
+use std::collections::{HashMap, HashSet};
 
 #[test]
 fn de() {

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -1,9 +1,15 @@
 use nanoserde::{DeRon, SerRon};
 
 use std::{
-    collections::{BTreeSet, HashMap, HashSet, LinkedList},
+    collections::{BTreeSet, LinkedList},
     sync::atomic::AtomicBool,
 };
+
+#[cfg(feature = "no_std")]
+use hashbrown::{HashMap, HashSet};
+
+#[cfg(not(feature = "no_std"))]
+use std::collections::{HashMap, HashSet};
 
 #[test]
 fn ron_de() {

--- a/tests/ser_de.rs
+++ b/tests/ser_de.rs
@@ -1,5 +1,9 @@
 use nanoserde::{DeBin, DeJson, DeRon, SerBin, SerJson, SerRon};
 
+#[cfg(feature = "no_std")]
+use hashbrown::HashMap;
+
+#[cfg(not(feature = "no_std"))]
 use std::collections::HashMap;
 
 #[test]


### PR DESCRIPTION
First commit closes #85, and fixes an issue with the no-std feature cfg. Also a couple clippy lints. 

Second commit fixes the `no_std` feature (which has apparently been broken for a while) and separates the `std` and `no_std` ci runs. 