### PR TITLE
Exclude self bounds

### DIFF
--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -73,7 +73,7 @@ pub(crate) fn struct_bounds_strings(struct_: &Struct, bound_name: &str) -> (Stri
         return ("".to_string(), "".to_string());
     }
     let mut generic_w_bounds = "<".to_string();
-    for generic in generics.iter() {
+    for generic in generics.iter().filter(|g| g.ident_only() != "Self") {
         generic_w_bounds += generic
             .full_with_const(&[format!("nanoserde::{}", bound_name).as_str()], true)
             .as_str();
@@ -82,7 +82,7 @@ pub(crate) fn struct_bounds_strings(struct_: &Struct, bound_name: &str) -> (Stri
     generic_w_bounds += ">";
 
     let mut generic_no_bounds = "<".to_string();
-    for generic in generics.iter() {
+    for generic in generics.iter().filter(|g| g.ident_only() != "Self") {
         generic_no_bounds += generic.ident_only().as_str();
         generic_no_bounds += ", ";
     }
@@ -97,7 +97,7 @@ pub(crate) fn enum_bounds_strings(enum_: &Enum, bound_name: &str) -> (String, St
         return ("".to_string(), "".to_string());
     }
     let mut generic_w_bounds = "<".to_string();
-    for generic in generics.iter() {
+    for generic in generics.iter().filter(|g| g.ident_only() != "Self") {
         generic_w_bounds += generic
             .full_with_const(&[format!("nanoserde::{}", bound_name).as_str()], true)
             .as_str();
@@ -106,7 +106,7 @@ pub(crate) fn enum_bounds_strings(enum_: &Enum, bound_name: &str) -> (String, St
     generic_w_bounds += ">";
 
     let mut generic_no_bounds = "<".to_string();
-    for generic in generics.iter() {
+    for generic in generics.iter().filter(|g| g.ident_only() != "Self") {
         generic_no_bounds += generic.ident_only().as_str();
         generic_no_bounds += ", ";
     }

--- a/tests/bin.rs
+++ b/tests/bin.rs
@@ -122,7 +122,10 @@ fn field_proxy() {
 #[test]
 fn field_ignore_self_bound() {
     #[derive(SerBin)]
-    pub struct Serializable<'a> where Self: 'a {
+    pub struct Serializable<'a>
+    where
+        Self: 'a,
+    {
         foo: &'a i32,
     }
 
@@ -133,9 +136,7 @@ fn field_ignore_self_bound() {
 
     let foo_base = 42;
 
-    let test = Serializable {
-        foo: &42
-    };
+    let test = Serializable { foo: &42 };
 
     let bytes = SerBin::serialize_bin(&test);
     let deser: DeSerializable = DeBin::deserialize_bin(&bytes).unwrap();

--- a/tests/bin.rs
+++ b/tests/bin.rs
@@ -120,6 +120,29 @@ fn field_proxy() {
 }
 
 #[test]
+fn field_ignore_self_bound() {
+    #[derive(SerBin)]
+    pub struct Serializable<'a> where Self: 'a {
+        foo: &'a i32,
+    }
+
+    #[derive(DeBin)]
+    pub struct DeSerializable {
+        foo: i32,
+    }
+
+    let foo_base = 42;
+
+    let test = Serializable {
+        foo: &42
+    };
+
+    let bytes = SerBin::serialize_bin(&test);
+    let deser: DeSerializable = DeBin::deserialize_bin(&bytes).unwrap();
+    assert_eq!(foo_base, deser.foo);
+}
+
+#[test]
 fn struct_proxy() {
     #[derive(PartialEq, Debug)]
     struct NonSerializable<T: PartialEq> {


### PR DESCRIPTION
Excludes an illegal bound type from being applied by the proc macro