### PR TITLE
Json ron deser large numbers error

### DIFF
--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -714,9 +714,9 @@ impl_ser_de_json_unsigned!(u32, core::u32::MAX);
 impl_ser_de_json_unsigned!(u16, core::u16::MAX);
 impl_ser_de_json_unsigned!(u8, core::u8::MAX);
 impl_ser_de_json_signed!(i64, core::i64::MIN, core::i64::MAX);
-impl_ser_de_json_signed!(i32, core::i64::MIN, core::i64::MAX);
-impl_ser_de_json_signed!(i16, core::i64::MIN, core::i64::MAX);
-impl_ser_de_json_signed!(i8, core::i64::MIN, core::i8::MAX);
+impl_ser_de_json_signed!(i32, core::i32::MIN, core::i32::MAX);
+impl_ser_de_json_signed!(i16, core::i16::MIN, core::i16::MAX);
+impl_ser_de_json_signed!(i8, core::i8::MIN, core::i8::MAX);
 impl_ser_de_json_float!(f64);
 impl_ser_de_json_float!(f32);
 

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -754,9 +754,9 @@ impl_ser_de_ron_unsigned!(u32, core::u32::MAX);
 impl_ser_de_ron_unsigned!(u16, core::u16::MAX);
 impl_ser_de_ron_unsigned!(u8, core::u8::MAX);
 impl_ser_de_ron_signed!(i64, core::i64::MIN, core::i64::MAX);
-impl_ser_de_ron_signed!(i32, core::i64::MIN, core::i64::MAX);
-impl_ser_de_ron_signed!(i16, core::i64::MIN, core::i64::MAX);
-impl_ser_de_ron_signed!(i8, core::i64::MIN, core::i8::MAX);
+impl_ser_de_ron_signed!(i32, core::i32::MIN, core::i32::MAX);
+impl_ser_de_ron_signed!(i16, core::i16::MIN, core::i16::MAX);
+impl_ser_de_ron_signed!(i8, core::i8::MIN, core::i8::MAX);
 impl_ser_de_ron_float!(f64);
 impl_ser_de_ron_float!(f32);
 


### PR DESCRIPTION
closes #89. The min/max values for non-64bit primitives were all set to use the 64 bit equivalent for some reason, this PR sets them to the appropriate `::MIN/MAX` values