### PR TITLE
Rework TOML token parsing

### DIFF
--- a/src/toml.rs
+++ b/src/toml.rs
@@ -14,28 +14,28 @@ use std::collections::HashMap;
 /// ABNF line: https://github.com/toml-lang/toml/blob/2431aa308a7bc97eeb50673748606e23a6e0f201/toml.abnf#L55
 macro_rules! ident_chars {
     () => {
-        0x41..=0x5A
-        | 0x61..=0x7A
-        | 0x30..=0x39
-        | 0x2D
-        | 0x5F
-        | 0xB2
-        | 0xB3
-        | 0xB9
-        | 0xBC..=0xBE
-        | 0xC0..=0xD6
-        | 0xD8..=0xF6
-        | 0xF8..=0x37D
-        | 0x37F..=0x1FFF
-        | 0x200C..=0x200D
-        | 0x203F..=0x2040
-        | 0x2070..=0x218F
-        | 0x2460..=0x24FF
-        | 0x2C00..=0x2FEF
-        | 0x3001..=0xD7FF
-        | 0xF900..=0xFDCF
-        | 0xFDF0..=0xFFFD
-        | 0x10000..=0xEFFFF
+        '\u{41}'..='\u{5A}'
+        | '\u{61}'..='\u{7A}'
+        | '\u{30}'..='\u{39}'
+        | '\u{2D}'
+        | '\u{5F}'
+        | '\u{B2}'
+        | '\u{B3}'
+        | '\u{B9}'
+        | '\u{BC}'..='\u{BE}'
+        | '\u{C0}'..='\u{D6}'
+        | '\u{D8}'..='\u{F6}'
+        | '\u{F8}'..='\u{37D}'
+        | '\u{37F}'..='\u{1FFF}'
+        | '\u{200C}'..='\u{200D}'
+        | '\u{203F}'..='\u{2040}'
+        | '\u{2070}'..='\u{218F}'
+        | '\u{2460}'..='\u{24FF}'
+        | '\u{2C00}'..='\u{2FEF}'
+        | '\u{3001}'..='\u{D7FF}'
+        | '\u{F900}'..='\u{FDCF}'
+        | '\u{FDF0}'..='\u{FFFD}'
+        | '\u{10000}'..='\u{EFFFF}'
     }
 }
 
@@ -434,29 +434,24 @@ impl TomlParser {
             }
 
             #[allow(unreachable_patterns)]
-            match self.cur as u32 {
-                // ,
-                0x2C => {
+            match self.cur {
+                ',' => {
                     self.next(i);
                     return Ok(TomlTok::Comma);
                 }
-                // [
-                0x5B => {
+                '[' => {
                     self.next(i);
                     return Ok(TomlTok::BlockOpen);
                 }
-                // ]
-                0x5D => {
+                ']' => {
                     self.next(i);
                     return Ok(TomlTok::BlockClose);
                 }
-                // =
-                0x3D => {
+                '=' => {
                     self.next(i);
                     return Ok(TomlTok::Equals);
                 }
-                // #
-                0x23 => {
+                '#' => {
                     while self.cur != '\n' && self.cur != '\0' {
                         self.next(i);
                     }
@@ -469,10 +464,8 @@ impl TomlParser {
                         self.next(i);
                     }
                 }
-                // + - 0-9
-                0x2B | 0x2D | 0x30..=0x39 => return self.parse_num(i),
-                // "
-                0x22 => {
+                '+' | '-' | '0'..='9' => return self.parse_num(i),
+                '"' => {
                     let mut val = String::new();
                     self.next(i);
                     let mut braces = 1;
@@ -518,7 +511,7 @@ impl TomlParser {
 
     /// Parse an ident or similar, starting with the current character.
     fn parse_ident(&mut self, i: &mut Chars, mut start: String) -> Result<TomlTok, TomlErr> {
-        while matches!(self.cur as u32, ident_chars!()) {
+        while matches!(self.cur, ident_chars!()) {
             start.push(self.cur);
             self.next(i);
         }
@@ -618,7 +611,7 @@ impl TomlParser {
             // TODO rework this
         }
 
-        if matches!(self.cur as u32, ident_chars!()) {
+        if matches!(self.cur, ident_chars!()) {
             return self.parse_ident(i, num);
         }
 

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -63,6 +63,7 @@ pub enum TomlTok {
     I64(i64),
     F64(f64),
     Bool(bool),
+    // TODO add option to enforce + sign for conversion to ident
     Nan(bool),
     Inf(bool),
     Date(String),
@@ -70,7 +71,6 @@ pub enum TomlTok {
     BlockOpen,
     BlockClose,
     Comma,
-    Bof,
     Eof,
 }
 

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -527,15 +527,11 @@ impl TomlParser {
                         if is_neg {
                             if let Ok(num) = num.parse() {
                                 return Ok(TomlTok::I64(num));
-                            } else {
-                                return self.parse_ident(i, num);
                             }
-                        }
-                        if let Ok(num) = num.parse() {
+                        } else if let Ok(num) = num.parse() {
                             return Ok(TomlTok::U64(num));
-                        } else {
-                            return self.parse_ident(i, num);
                         }
+                        return self.parse_ident(i, num);
                     }
                 }
                 0x22 => {

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -39,6 +39,13 @@ macro_rules! ident_chars {
     }
 }
 
+/// Pattern matching a character that can terminate a valid ident.
+macro_rules! ident_term_chars {
+    () => {
+        ' ' | '\t' | '\n' | '\0' | '='
+    };
+}
+
 /// A parser for TOML string values.
 ///
 /// ```rust

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -621,6 +621,6 @@ impl TomlParser {
             }
         }
 
-        return self.parse_ident(i, num);
+        return Err(self.err_parse("tokenizer"));
     }
 }

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -42,7 +42,7 @@ macro_rules! ident_chars {
 /// Pattern matching a character that can terminate a valid ident.
 macro_rules! ident_term_chars {
     () => {
-        ' ' | '\t' | '\n' | '\0' | '='
+        ' ' | '\t' | '\n' | '\0' | '=' | ']'
     };
 }
 

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -437,10 +437,10 @@ impl TomlParser {
                                 self.next(i);
                                 return Ok(TomlTok::Nan(is_neg));
                             } else {
-                                return Err(self.err_parse("nan"));
+                                return self.parse_bare_key(i, num);
                             }
                         } else {
-                            return Err(self.err_parse("nan"));
+                            return self.parse_bare_key(i, num);
                         }
                     }
                     if self.cur == 'i' {
@@ -451,10 +451,10 @@ impl TomlParser {
                                 self.next(i);
                                 return Ok(TomlTok::Inf(is_neg));
                             } else {
-                                return Err(self.err_parse("inf"));
+                                return self.parse_bare_key(i, num);
                             }
                         } else {
-                            return Err(self.err_parse("nan"));
+                            return self.parse_bare_key(i, num);
                         }
                     }
                     while self.cur >= '0' && self.cur <= '9' || self.cur == '_' {
@@ -495,13 +495,13 @@ impl TomlParser {
                             if let Ok(num) = num.parse() {
                                 return Ok(TomlTok::I64(num));
                             } else {
-                                return Err(self.err_parse("number"));
+                                return self.parse_bare_key(i, num);
                             }
                         }
                         if let Ok(num) = num.parse() {
                             return Ok(TomlTok::U64(num));
                         } else {
-                            return Err(self.err_parse("number"));
+                            return self.parse_bare_key(i, num);
                         }
                     }
                 }
@@ -544,10 +544,21 @@ impl TomlParser {
                     self.next(i);
                     return Ok(TomlTok::Str(val));
                 }
-                bare_key_chars!() => todo!("parse unquoted key"),
+                bare_key_chars!() => return self.parse_bare_key(i, String::new()),
                 _ => return Err(self.err_parse("tokenizer")),
             }
         }
+    }
+
+    /// Parse a bare key from the current character.
+    fn parse_bare_key(&mut self, i: &mut Chars, mut start: String) -> Result<TomlTok, TomlErr> {
+        let mut val = String::new();
+        while matches!(self.cur as u32, bare_key_chars!()) {
+            val.push(self.cur);
+            self.next(i);
+        }
+
+        todo!("Return paths for parsing bare key")
     }
 
     fn next_ident(&mut self, i: &mut Chars, mut start: String) -> Result<TomlTok, TomlErr> {

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -604,6 +604,10 @@ impl TomlParser {
             // TODO rework this
         }
 
+        if matches!(self.cur as u32, ident_chars!()) {
+            return self.parse_ident(i, num);
+        }
+
         match negative {
             true => {
                 if let Ok(num) = num.parse() {

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -635,6 +635,6 @@ impl TomlParser {
             }
         }
 
-        return Err(self.err_parse("tokenizer"));
+        Err(self.err_parse("tokenizer"))
     }
 }

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -81,35 +81,35 @@ pub enum TomlTok {
     Eof,
 }
 
-impl Into<String> for TomlTok {
-    fn into(self) -> String {
-        match self {
-            Self::Ident(string) => string,
-            Self::Str(string) => string,
-            Self::U64(number) => number.to_string(),
-            Self::I64(number) => number.to_string(),
-            Self::F64(number) => number.to_string(),
-            Self::Bool(boolean) => boolean.to_string(),
-            Self::Nan(negative) => {
+impl From<TomlTok> for String {
+    fn from(value: TomlTok) -> Self {
+        match value {
+            TomlTok::Ident(string) => string,
+            TomlTok::Str(string) => string,
+            TomlTok::U64(number) => number.to_string(),
+            TomlTok::I64(number) => number.to_string(),
+            TomlTok::F64(number) => number.to_string(),
+            TomlTok::Bool(boolean) => boolean.to_string(),
+            TomlTok::Nan(negative) => {
                 if negative {
                     "-nan".to_string()
                 } else {
                     "nan".to_string()
                 }
             }
-            Self::Inf(negative) => {
+            TomlTok::Inf(negative) => {
                 if negative {
                     "-inf".to_string()
                 } else {
                     "inf".to_string()
                 }
             }
-            Self::Date(string) => string,
-            Self::Equals => '='.to_string(),
-            Self::BlockOpen => '['.to_string(),
-            Self::BlockClose => ']'.to_string(),
-            Self::Comma => ','.to_string(),
-            Self::Eof => '\0'.to_string(),
+            TomlTok::Date(string) => string,
+            TomlTok::Equals => '='.to_string(),
+            TomlTok::BlockOpen => '['.to_string(),
+            TomlTok::BlockClose => ']'.to_string(),
+            TomlTok::Comma => ','.to_string(),
+            TomlTok::Eof => '\0'.to_string(),
         }
     }
 }

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -557,44 +557,18 @@ impl TomlParser {
             self.next(i);
         }
 
-        todo!("Return paths for parsing bare key")
-    }
-
-    fn next_ident(&mut self, i: &mut Chars, mut start: String) -> Result<TomlTok, TomlErr> {
-        while self.cur >= 'a' && self.cur <= 'z'
-            || self.cur >= 'A' && self.cur <= 'Z'
-            || self.cur == '_'
-            || self.cur == '-'
-        {
+        if self.cur == '.' {
             start.push(self.cur);
             self.next(i);
+            return self.parse_ident(i, start); // recursion here could be a problem
         }
-        if self.cur == '.' {
-            while self.cur == '.' {
-                self.next(i);
-                while self.cur >= 'a' && self.cur <= 'z'
-                    || self.cur >= 'A' && self.cur <= 'Z'
-                    || self.cur == '_'
-                    || self.cur == '-'
-                {
-                    start.push(self.cur);
-                    self.next(i);
-                }
-            }
-            return Ok(TomlTok::Ident(start));
-        }
-        if start == "true" {
-            return Ok(TomlTok::Bool(true));
-        }
-        if start == "false" {
-            return Ok(TomlTok::Bool(false));
-        }
-        if start == "inf" {
-            return Ok(TomlTok::Inf(false));
-        }
-        if start == "nan" {
-            return Ok(TomlTok::Nan(false));
-        }
-        return Ok(TomlTok::Ident(start));
+
+        Ok(match start.as_ref() {
+            "true" => TomlTok::Bool(true),
+            "false" => TomlTok::Bool(false),
+            "inf" => TomlTok::Inf(false),
+            "nan" => TomlTok::Nan(false),
+            _ => TomlTok::Ident(start),
+        })
     }
 }

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -560,10 +560,8 @@ impl TomlParser {
                 if self.cur == 'n' {
                     num.push(self.cur);
                     self.next(i);
-                    if matches!(self.cur as u32, ident_chars!()) {
+                    if matches!(self.cur, ident_term_chars!()) {
                         return Ok(TomlTok::Nan(negative));
-                    } else {
-                        return self.parse_ident(i, num);
                     }
                 }
             }
@@ -576,10 +574,8 @@ impl TomlParser {
                 if self.cur == 'f' {
                     num.push(self.cur);
                     self.next(i);
-                    if matches!(self.cur as u32, ident_chars!()) {
+                    if matches!(self.cur, ident_term_chars!()) {
                         return Ok(TomlTok::Inf(negative));
-                    } else {
-                        return self.parse_ident(i, num);
                     }
                 }
             }

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -10,6 +10,35 @@ use hashbrown::HashMap;
 #[cfg(not(feature = "no_std"))]
 use std::collections::HashMap;
 
+/// Pattern matching any valid bare key character as u32.
+/// ABNF line: https://github.com/toml-lang/toml/blob/2431aa308a7bc97eeb50673748606e23a6e0f201/toml.abnf#L55
+macro_rules! bare_key_chars {
+    () => {
+        0x41..=0x5A
+        | 0x61..=0x7A
+        | 0x30..=0x39
+        | 0x2D
+        | 0x5F
+        | 0xB2
+        | 0xB3
+        | 0xB9
+        | 0xBC..=0xBE
+        | 0xC0..=0xD6
+        | 0xD8..=0xF6
+        | 0xF8..=0x37D
+        | 0x37F..=0x1FFF
+        | 0x200C..=0x200D
+        | 0x203F..=0x2040
+        | 0x2070..=0x218F
+        | 0x2460..=0x24FF
+        | 0x2C00..=0x2FEF
+        | 0x3001..=0xD7FF
+        | 0xF900..=0xFDCF
+        | 0xFDF0..=0xFFFD
+        | 0x10000..=0xEFFFF
+    }
+}
+
 /// A parser for TOML string values.
 ///
 /// ```rust

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -74,6 +74,39 @@ pub enum TomlTok {
     Eof,
 }
 
+impl Into<String> for TomlTok {
+    fn into(self) -> String {
+        match self {
+            Self::Ident(string) => string,
+            Self::Str(string) => string,
+            Self::U64(number) => number.to_string(),
+            Self::I64(number) => number.to_string(),
+            Self::F64(number) => number.to_string(),
+            Self::Bool(boolean) => boolean.to_string(),
+            Self::Nan(negative) => {
+                if negative {
+                    "-nan".to_string()
+                } else {
+                    "nan".to_string()
+                }
+            }
+            Self::Inf(negative) => {
+                if negative {
+                    "-inf".to_string()
+                } else {
+                    "inf".to_string()
+                }
+            }
+            Self::Date(string) => string,
+            Self::Equals => '='.to_string(),
+            Self::BlockOpen => '['.to_string(),
+            Self::BlockClose => ']'.to_string(),
+            Self::Comma => ','.to_string(),
+            Self::Eof => '\0'.to_string(),
+        }
+    }
+}
+
 /// A TOML value.
 #[derive(Debug, PartialEq)]
 pub enum Toml {

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -379,6 +379,8 @@ impl TomlParser {
             if self.cur == '\0' {
                 return Ok(TomlTok::Eof);
             }
+
+            #[allow(unreachable_patterns)]
             match self.cur as u32 {
                 0x2C => {
                     // ,

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -546,15 +546,19 @@ impl TomlParser {
         if self.cur == '+' {
             self.next(i)
         } else if self.cur == '-' {
+            num.push(self.cur);
             negative = true;
             self.next(i);
         }
 
         if self.cur == 'n' {
+            num.push(self.cur);
             self.next(i);
             if self.cur == 'a' {
+                num.push(self.cur);
                 self.next(i);
                 if self.cur == 'n' {
+                    num.push(self.cur);
                     self.next(i);
                     if matches!(self.cur as u32, ident_chars!()) {
                         return Ok(TomlTok::Nan(negative));
@@ -564,10 +568,13 @@ impl TomlParser {
                 }
             }
         } else if self.cur == 'i' {
+            num.push(self.cur);
             self.next(i);
             if self.cur == 'n' {
+                num.push(self.cur);
                 self.next(i);
                 if self.cur == 'f' {
+                    num.push(self.cur);
                     self.next(i);
                     if matches!(self.cur as u32, ident_chars!()) {
                         return Ok(TomlTok::Inf(negative));

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -529,13 +529,17 @@ impl TomlParser {
             return self.parse_ident(i, start); // recursion here could be a problem
         }
 
-        Ok(match start.as_ref() {
-            "true" => TomlTok::Bool(true),
-            "false" => TomlTok::Bool(false),
-            "inf" => TomlTok::Inf(false),
-            "nan" => TomlTok::Nan(false),
-            _ => TomlTok::Ident(start),
-        })
+        if matches!(self.cur, ident_term_chars!()) {
+            return Ok(match start.as_ref() {
+                "true" => TomlTok::Bool(true),
+                "false" => TomlTok::Bool(false),
+                "inf" => TomlTok::Inf(false),
+                "nan" => TomlTok::Nan(false),
+                _ => TomlTok::Ident(start),
+            });
+        }
+
+        Err(self.err_parse("tokenizer"))
     }
 
     /// Parses a number (or an ident that starts with numbers), starting with the current character.

--- a/tests/toml.rs
+++ b/tests/toml.rs
@@ -90,16 +90,21 @@ fn assert_specific_toml_types() {
 #[test]
 fn key_start_num() {
     let toml_str = r#"
-    [table]
-    1key = value
-    key = 1value
-    -0key = +nanvalue
-"#;
+        [foo.bar.baz]
+        1key = "myval"
+        -inf = 0
+        2024-04-30 = 100
+        ½ = 0.5
+    "#;
+
     assert_eq!(
-        *TomlParser::parse(toml_str).unwrap()["table"].arr(),
-        vec![HashMap::from([(
-            "1key".to_string(),
-            Toml::Str("value".to_string())
-        ),])]
+        // TODO parse dotted keys correctly (nested table)
+        *TomlParser::parse(toml_str).unwrap()["foo.bar.baz"].arr(),
+        vec![HashMap::from([
+            ("1key".to_string(), Toml::Str("myval".to_string())),
+            ("-inf".to_string(), Toml::Num(0.0)),
+            ("2024-04-30".to_string(), Toml::Num(100.0)),
+            ("½".to_string(), Toml::Num(0.5))
+        ])]
     );
 }

--- a/tests/toml.rs
+++ b/tests/toml.rs
@@ -88,23 +88,25 @@ fn assert_specific_toml_types() {
 }
 
 #[test]
-fn key_start_num() {
+fn toml_key_chars() {
     let toml_str = r#"
         [foo.bar.baz]
-        1key = "myval"
+        123abc456def = "myval"
         -inf = 0
         2024-04-30 = 100
         ½ = 0.5
     "#;
 
     assert_eq!(
-        // TODO parse dotted keys correctly (nested table)
-        *TomlParser::parse(toml_str).unwrap()["foo.bar.baz"].arr(),
-        vec![HashMap::from([
-            ("1key".to_string(), Toml::Str("myval".to_string())),
-            ("-inf".to_string(), Toml::Num(0.0)),
-            ("2024-04-30".to_string(), Toml::Num(100.0)),
-            ("½".to_string(), Toml::Num(0.5))
-        ])]
+        TomlParser::parse(toml_str).unwrap(),
+        HashMap::from([
+            (
+                "foo.bar.baz.123abc456def".to_string(),
+                Toml::Str("myval".to_string())
+            ),
+            ("foo.bar.baz.-inf".to_string(), Toml::Num(0.0)),
+            ("foo.bar.baz.2024-04-30".to_string(), Toml::Num(100.0)),
+            ("foo.bar.baz.½".to_string(), Toml::Num(0.5))
+        ])
     );
 }

--- a/tests/toml.rs
+++ b/tests/toml.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "no_std")]
+use hashbrown::HashMap;
+#[cfg(not(feature = "no_std"))]
 use std::collections::HashMap;
 
 use nanoserde::Toml;

--- a/tests/toml.rs
+++ b/tests/toml.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use nanoserde::Toml;
 use nanoserde::TomlParser;
 
@@ -82,5 +84,22 @@ fn assert_specific_toml_types() {
             Toml::Num(3.0),
             Toml::Num(4.0)
         ]
+    );
+}
+
+#[test]
+fn key_start_num() {
+    let toml_str = r#"
+    [table]
+    1key = value
+    key = 1value
+    -0key = +nanvalue
+"#;
+    assert_eq!(
+        *TomlParser::parse(toml_str).unwrap()["table"].arr(),
+        vec![HashMap::from([(
+            "1key".to_string(),
+            Toml::Str("value".to_string())
+        ),])]
     );
 }


### PR DESCRIPTION
This PR closes #81 and also allows a number of other valid identifiers to be parsed by reworking the logic for parsing TOML tokens from characters.

For example, all of the identifiers in the following document are valid according to the TOML spec (ABNF [here](https://github.com/toml-lang/toml/blob/main/toml.abnf)), but none are currently able to be parsed:

```toml
[foo.bar.baz]
1key = "myval"
-inf = 0
2024-04-30 = 100
½ = 0.5
```
(although even github markdown highlighting doesn't get that last one)

