### PR TITLE
Support Enum numbered variant parsing

### DIFF
--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -1232,6 +1232,12 @@ fn next_enum<T: Iterator<Item = TokenTree> + Clone>(mut source: &mut Peekable<T>
             break;
         }
 
+        if next_exact_punct(&mut body, "=").is_some() {
+            body.next();
+            let _maybe_coma = next_exact_punct(&mut body, ",");
+            continue;
+        }
+
         let attributes = next_attributes_list(&mut body);
 
         let variant_name = next_ident(&mut body).expect("Unnamed variants are not supported");
@@ -1260,6 +1266,7 @@ fn next_enum<T: Iterator<Item = TokenTree> + Clone>(mut source: &mut Peekable<T>
                 vis: Visibility::Public,
             });
         }
+
         let _maybe_semicolon = next_exact_punct(&mut body, ";");
         let _maybe_coma = next_exact_punct(&mut body, ",");
     }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -632,6 +632,37 @@ fn de_enum() {
 #[test]
 fn de_ser_enum() {
     #[derive(DeJson, SerJson, PartialEq, Debug)]
+    pub enum Fud {
+        A = 0,
+        B = 1,
+        C = 2,
+    }
+
+    #[derive(DeJson, SerJson, PartialEq, Debug)]
+    pub struct Bar {
+        foo1: Fud,
+        foo2: Fud,
+        foo3: Fud,
+    }
+
+    let json = "{\"foo1\":\"A\",\"foo2\":\"B\",\"foo3\":\"C\"}";
+
+    let data = Bar {
+        foo1: Fud::A,
+        foo2: Fud::B,
+        foo3: Fud::C,
+    };
+
+    let serialized = SerJson::serialize_json(&data);
+    assert_eq!(serialized, json);
+
+    let deserialized: Bar = DeJson::deserialize_json(&serialized).unwrap();
+    assert_eq!(deserialized, data);
+}
+
+#[test]
+fn de_ser_enum_complex() {
+    #[derive(DeJson, SerJson, PartialEq, Debug)]
     pub enum Foo {
         A,
         B { x: i32 },

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -381,6 +381,70 @@ fn de_enum() {
 }
 
 #[test]
+fn de_ser_enum() {
+    #[derive(SerRon, DeRon, PartialEq, Debug)]
+    pub enum Fud {
+        A = 0,
+        B = 1,
+        C = 2,
+    }
+
+    #[derive(SerRon, DeRon, PartialEq, Debug)]
+    pub struct Bar {
+        foo1: Fud,
+        foo2: Fud,
+        foo3: Fud,
+    }
+
+    let ron = "(\n    foo1:A,\n    foo2:B,\n    foo3:C,\n)";
+
+    let data = Bar {
+        foo1: Fud::A,
+        foo2: Fud::B,
+        foo3: Fud::C,
+    };
+    let serialized = SerRon::serialize_ron(&data);
+
+    assert_eq!(serialized, ron);
+
+    let deserialized: Bar = DeRon::deserialize_ron(&serialized).unwrap();
+    assert_eq!(deserialized, data);
+}
+
+#[test]
+fn ser_enum_complex() {
+    #[derive(SerRon, DeRon, PartialEq, Debug)]
+    pub enum Foo {
+        A,
+        B(i32, String),
+        C { a: i32, b: String },
+    }
+
+    #[derive(SerRon, DeRon, PartialEq, Debug)]
+    pub struct Bar {
+        foo1: Foo,
+        foo2: Foo,
+        foo3: Foo,
+    }
+
+    let ron = "(\n    foo1:A,\n    foo2:B(1, \"asd\"),\n    foo3:C(\n        a:2,\n        b:\"qwe\",\n    ),\n)";
+
+    let data = Bar {
+        foo1: Foo::A,
+        foo2: Foo::B(1, String::from("asd")),
+        foo3: Foo::C {
+            a: 2,
+            b: String::from("qwe"),
+        },
+    };
+    let serialized = SerRon::serialize_ron(&data);
+    assert_eq!(serialized, ron);
+
+    let deserialized: Bar = DeRon::deserialize_ron(&serialized).unwrap();
+    assert_eq!(deserialized, data);
+}
+
+#[test]
 fn test_various_escapes() {
     let ron = r#""\n\t\u0020\f\b\\\"\/\ud83d\uDE0B\r""#;
     let unescaped: String = DeRon::deserialize_ron(ron).unwrap();


### PR DESCRIPTION
Allows ser/de of enums such as:

```rust
pub enum Fud {
    A = 0,
    B = 1,
    C = 2,
}
```

Should close #101