### PR TITLE
Use default value instead of None for all types when using skip attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,36 +33,39 @@ For more examples take a look at [tests](/tests)
 
 ## Features support matrix:
 
-| Feature                                        | json   | bin   | ron    | toml  |
-| ---------------------------------------------- | ------ | ----- | ------ | ----- |
-| serialization                                  | yes    | yes   | yes    | no    |
-| deserialization                                | yes    | yes   | yes    | no    |
-| container: Struct                              | yes    | yes   | yes    | no    |
-| container: Tuple Struct                        | no     | yes   | yes    | no    |
-| container: Enum                                | yes    | yes   | yes    | no    |
-| field: `std::collections::HashMap`             | yes    | yes   | yes    | no    |
-| field: `std::vec::Vec`                         | yes    | yes   | yes    | no    |
-| field: `Option`                                | yes    | yes   | yes    | no    |
-| field: `i*`/`f*`/`String`/`T: De*/Ser*`        | yes    | yes   | yes    | no    |
-| field attribute: `#[nserde(default)]`          | yes    | no    | yes    | no    |
-| field attribute: `#[nserde(rename = "")]`      | yes    | yes   | yes    | no    |
-| field attribute: `#[nserde(proxy = "")]`       | no     | yes   | no     | no    |
-| container attribute: `#[nserde(default)]`      | yes    | no    | yes    | no    |
-| container attribute: `#[nserde(rename = "")]`  | yes    | yes   | yes    | no    |
-| container attribute: `#[nserde(proxy = "")]`   | yes    | yes   | no     | no    |
-| container attribute: `#[nserde(transparent)]`  | yes    | no    | no     | no    |
+| Feature                                             | json   | bin   | ron    | toml  |
+| --------------------------------------------------- | ------ | ----- | ------ | ----- |
+| serialization                                       | yes    | yes   | yes    | no    |
+| deserialization                                     | yes    | yes   | yes    | no    |
+| container: Struct                                   | yes    | yes   | yes    | no    |
+| container: Tuple Struct                             | no     | yes   | yes    | no    |
+| container: Enum                                     | yes    | yes   | yes    | no    |
+| field: `std::collections::HashMap`                  | yes    | yes   | yes    | no    |
+| field: `std::vec::Vec`                              | yes    | yes   | yes    | no    |
+| field: `Option`                                     | yes    | yes   | yes    | no    |
+| field: `i*`/`f*`/`String`/`T: De*/Ser*`             | yes    | yes   | yes    | no    |
+| field attribute: `#[nserde(default)]`               | yes    | no    | yes    | no    |
+| field attribute: `#[nserde(rename = "")]`           | yes    | yes   | yes    | no    |
+| field attribute: `#[nserde(proxy = "")]`            | no     | yes   | no     | no    |
+| container attribute: `#[nserde(default)]`           | yes    | no    | yes    | no    |
+| container attribute: `#[nserde(default = "")]`      | yes    | no    | yes    | no    |
+| container attribute: `#[nserde(default_with = "")]` | yes    | no    | yes    | no    |
+| container attribute: `#[nserde(skip)]`              | yes    | no    | yes    | no    |
+| container attribute: `#[nserde(rename = "")]`       | yes    | yes   | yes    | no    |
+| container attribute: `#[nserde(proxy = "")]`        | yes    | yes   | no     | no    |
+| container attribute: `#[nserde(transparent)]`       | yes    | no    | no     | no    |
 
 ## Crate features:
 
-All features are enabled by default. To enable only specific formats, import nanoserde using 
+All features are enabled by default. To enable only specific formats, import nanoserde using
 ```toml
 nanoserde = { version = "*", default-features = false, features = ["std", "{format feature name}"] }
 ```
 in your `Cargo.toml` and add one or more of the following crate features:
 
-| Format    | Feature Name   | 
+| Format    | Feature Name   |
 | ----------| -------------- |
-| Binary    | `binary`       | 
-| JSON      | `json`         | 
+| Binary    | `binary`       |
+| JSON      | `json`         |
 | RON       | `ron`          |
 | TOML      | `toml`         |

--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -175,7 +175,7 @@ pub fn derive_de_json_named(name: &str, defaults: bool, fields: &[Field]) -> Tok
             matches.push((json_fieldname.clone(), localvar.clone()));
             local_vars.push(localvar);
         } else {
-            unwraps.push(format!("None"));
+            unwraps.push(default_val.unwrap_or_else(|| String::from("Default::default()")));
         }
 
         struct_field_names.push(struct_fieldname);

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -69,7 +69,7 @@ pub fn attrs_transparent(attributes: &[crate::parse::Attribute]) -> bool {
         .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "transparent")
 }
 
-#[cfg(feature = "json")]
+#[cfg(any(feature = "json", feature = "ron"))]
 pub fn attrs_skip(attributes: &[crate::parse::Attribute]) -> bool {
     attributes
         .iter()

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -91,6 +91,9 @@ fn de_field_default() {
             Foo { x: 23 }
         }
     }
+    fn foo3_default() -> Foo {
+        Foo { x: 15 }
+    }
 
     #[derive(DeRon)]
     pub struct Test {
@@ -98,6 +101,8 @@ fn de_field_default() {
         #[nserde(default)]
         foo: Foo,
         foo2: Foo,
+        #[nserde(default_with = "foo3_default")]
+        foo3: Foo,
         b: f32,
     }
 
@@ -112,6 +117,56 @@ fn de_field_default() {
     assert_eq!(test.b, 2.);
     assert_eq!(test.foo.x, 23);
     assert_eq!(test.foo2.x, 3);
+    assert_eq!(test.foo3.x, 15);
+}
+
+#[test]
+fn de_ser_field_skip() {
+    #[derive(DeRon, SerRon, PartialEq, Debug)]
+    struct Foo {
+        x: i32,
+    }
+    impl Default for Foo {
+        fn default() -> Foo {
+            Foo { x: 23 }
+        }
+    }
+    fn foo3_default() -> Foo {
+        Foo { x: 15 }
+    }
+
+    #[derive(DeRon, SerRon, PartialEq, Debug)]
+    pub struct Test {
+        a: i32,
+        #[nserde(skip)]
+        foo: Foo,
+        foo2: Foo,
+        #[nserde(skip, default_with = "foo3_default")]
+        foo3: Foo,
+        b: f32,
+        #[nserde(skip)]
+        c: Option<i32>,
+    }
+
+    let ron = r#"(
+        a: 1,
+        b: 2.,
+        foo2: (x: 3)
+    )"#;
+
+    let mut test: Test = DeRon::deserialize_ron(ron).unwrap();
+    assert_eq!(test.a, 1);
+    assert_eq!(test.b, 2.);
+    assert_eq!(test.foo.x, 23);
+    assert_eq!(test.foo2.x, 3);
+    assert_eq!(test.foo3.x, 15);
+
+    test.c = Some(2);
+    let serialized = SerRon::serialize_ron(&test);
+
+    let test: Test = DeRon::deserialize_ron(ron).unwrap();
+    let deserialized: Test = DeRon::deserialize_ron(&serialized).unwrap();
+    assert_eq!(deserialized, test);
 }
 
 #[test]


### PR DESCRIPTION
When I was moving some stuff from serde to nanoserde it was little confusing why I get None value for f32 fields in macro expansion
I think this is the solution for issue #107