### PR TITLE
serde_json: serialize None as null if there is default attribute

### DIFF
--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -58,8 +58,9 @@ pub fn derive_ser_json_struct(struct_: &Struct) -> TokenStream {
 
             if field.ty.base() == "Option" {
                 let proxy_attr = crate::shared::attrs_proxy(&field.attributes);
-                let serialize_none_as_null_attr = shared::attrs_serialize_none_as_null(&struct_.attributes);
-                let null_on_none = serialize_none_as_null_attr && proxy_attr.is_none();
+                let struct_null_on_none = shared::attrs_serialize_none_as_null(&struct_.attributes);
+                let field_null_on_none = shared::attrs_serialize_none_as_null(&field.attributes);
+                let null_on_none = (field_null_on_none || struct_null_on_none) && proxy_attr.is_none();
                 let field_header = &format!("if first_field_was_serialized {{
                                                  s.conl();
                                              }};

--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -58,7 +58,8 @@ pub fn derive_ser_json_struct(struct_: &Struct) -> TokenStream {
 
             if field.ty.base() == "Option" {
                 let proxy_attr = crate::shared::attrs_proxy(&field.attributes);
-                let null_on_none = proxy_attr.is_none();
+                let serialize_none_as_null_attr = shared::attrs_serialize_none_as_null(&struct_.attributes);
+                let null_on_none = serialize_none_as_null_attr && proxy_attr.is_none();
                 let field_header = &format!("if first_field_was_serialized {{
                                                  s.conl();
                                              }};

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -76,6 +76,13 @@ pub fn attrs_skip(attributes: &[crate::parse::Attribute]) -> bool {
         .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "skip")
 }
 
+#[cfg(feature = "json")]
+pub fn attrs_serialize_none_as_null(attributes: &[crate::parse::Attribute]) -> bool {
+    attributes
+        .iter()
+        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "serialize_none_as_null")
+}
+
 #[cfg(any(feature = "binary", feature = "json"))]
 pub(crate) fn struct_bounds_strings(struct_: &Struct, bound_name: &str) -> (String, String) {
     let generics: &Vec<_> = &struct_.generics;

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -271,8 +271,8 @@ fn rename() {
 }
 
 #[test]
-fn de_ser_field_default() {
-    #[derive(DeJson, SerJson)]
+fn de_field_default() {
+    #[derive(DeJson)]
     struct Foo {
         x: i32,
     }
@@ -282,7 +282,7 @@ fn de_ser_field_default() {
         }
     }
 
-    #[derive(DeJson, SerJson)]
+    #[derive(DeJson)]
     pub struct Test {
         a: i32,
         #[nserde(default)]
@@ -302,8 +302,6 @@ fn de_ser_field_default() {
         g: Option<i32>,
         #[nserde(default = "world")]
         h: Option<String>,
-        #[nserde(default = 5.2)]
-        i: Option<f32>,
     }
 
     fn some_value() -> f32 {
@@ -312,8 +310,7 @@ fn de_ser_field_default() {
 
     let json = r#"{
         "a": 1,
-        "foo2": { "x": 3 },
-        "i": null
+        "foo2": { "x": 3 }
     }"#;
 
     let test: Test = DeJson::deserialize_json(json).unwrap();
@@ -327,11 +324,27 @@ fn de_ser_field_default() {
     assert_eq!(test.h, Some(String::from("world")));
     assert_eq!(test.foo.x, 23);
     assert_eq!(test.foo2.x, 3);
-    assert_eq!(test.i, None);
+}
 
-    let ser_json = r#"{"a":1,"foo":{"x":23},"foo2":{"x":3},"b":4.0,"c":3.0,"d":1,"e":"hello","f":{"x":3},"g":5,"h":"world","i":null}"#;
-    let serialized = SerJson::serialize_json(&test);
-    assert_eq!(serialized, ser_json);
+#[test]
+fn ser_none_as_null() {
+    #[derive(SerJson)]
+    struct Foo {
+        x: Option<i32>,
+    }
+
+    let a = Foo { x: None };
+    assert_eq!(SerJson::serialize_json(&a), r#"{}"#);
+
+    #[derive(SerJson)]
+    #[nserde(serialize_none_as_null)]
+    struct Foo2 {
+        x: Option<i32>,
+    }
+
+    let b = Foo2 { x: None };
+
+    assert_eq!(SerJson::serialize_json(&b), r#"{"x":null}"#);
 }
 
 #[test]

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -271,8 +271,8 @@ fn rename() {
 }
 
 #[test]
-fn de_field_default() {
-    #[derive(DeJson)]
+fn de_ser_field_default() {
+    #[derive(DeJson, SerJson)]
     struct Foo {
         x: i32,
     }
@@ -282,7 +282,7 @@ fn de_field_default() {
         }
     }
 
-    #[derive(DeJson)]
+    #[derive(DeJson, SerJson)]
     pub struct Test {
         a: i32,
         #[nserde(default)]
@@ -302,6 +302,8 @@ fn de_field_default() {
         g: Option<i32>,
         #[nserde(default = "world")]
         h: Option<String>,
+        #[nserde(default = 5.2)]
+        i: Option<f32>,
     }
 
     fn some_value() -> f32 {
@@ -310,7 +312,8 @@ fn de_field_default() {
 
     let json = r#"{
         "a": 1,
-        "foo2": { "x": 3 }
+        "foo2": { "x": 3 },
+        "i": null
     }"#;
 
     let test: Test = DeJson::deserialize_json(json).unwrap();
@@ -324,6 +327,11 @@ fn de_field_default() {
     assert_eq!(test.h, Some(String::from("world")));
     assert_eq!(test.foo.x, 23);
     assert_eq!(test.foo2.x, 3);
+    assert_eq!(test.i, None);
+
+    let ser_json = r#"{"a":1,"foo":{"x":23},"foo2":{"x":3},"b":4.0,"c":3.0,"d":1,"e":"hello","f":{"x":3},"g":5,"h":"world","i":null}"#;
+    let serialized = SerJson::serialize_json(&test);
+    assert_eq!(serialized, ser_json);
 }
 
 #[test]

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -345,6 +345,17 @@ fn ser_none_as_null() {
     let b = Foo2 { x: None };
 
     assert_eq!(SerJson::serialize_json(&b), r#"{"x":null}"#);
+
+    #[derive(SerJson)]
+    struct Foo3 {
+        x: Option<i32>,
+        #[nserde(serialize_none_as_null)]
+        y: Option<i32>,
+    }
+
+    let b = Foo3 { x: None, y: None };
+
+    assert_eq!(SerJson::serialize_json(&b), r#"{"y":null}"#);
 }
 
 #[test]


### PR DESCRIPTION
During porting of parsing lottie files to [this project](https://github.com/birhburh/macroquad_tamagotchi) from [lottie-rs](https://github.com/zimond/lottie-rs) I comparing serialized data
and nanoserde was skipping None fields with default attribute during serialization, but serde serializes them as null