### PR TITLE
add serialize_with and deserialize_with attribute families for json/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ For more examples take a look at [tests](/tests)
 | field: `Option`                                           | yes    | yes   | yes    | no    |
 | field: `i*`/`f*`/`String`/`T: De*/Ser*`                   | yes    | yes   | yes    | no    |
 | field attribute: `#[nserde(default)]`                     | yes    | no    | yes    | no    |
+| field attribute: `#[nserde(deserialize_json_with = "")]`  | yes    | no    | no     | no    |
+| field attribute: `#[nserde(deserialize_json_with = "")]`  | yes    | no    | no     | no    |
+| field attribute: `#[nserde(deserialize_bin_with = "")]`   | no     | yes   | no     | no    |
+| field attribute: `#[nserde(deserialize_bin_with = "")]`   | no     | yes   | no     | no    |
 | field attribute: `#[nserde(rename = "")]`                 | yes    | yes   | yes    | no    |
 | field attribute: `#[nserde(proxy = "")]`                  | no     | yes   | no     | no    |
 | field attribute: `#[nserde(serialize_none_as_null)]`      | yes    | no    | no     | no    |

--- a/derive/src/serde_bin.rs
+++ b/derive/src/serde_bin.rs
@@ -42,7 +42,7 @@ pub fn derive_ser_bin_struct(struct_: &Struct) -> TokenStream {
 
     for field in &struct_.fields {
         let field_name: &String = field.field_name.as_ref().unwrap();
-        let field_serializer = shared::attrs_serialize_bin_with(&field.attributes);
+        let field_serializer = crate::shared::attrs_serialize_bin_with(&field.attributes);
 
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(
@@ -91,7 +91,7 @@ pub fn derive_ser_bin_struct_unnamed(struct_: &Struct) -> TokenStream {
     let (generic_w_bounds, generic_no_bounds) = struct_bounds_strings(struct_, "SerBin");
 
     for (n, field) in struct_.fields.iter().enumerate() {
-        let field_serializer = shared::attrs_serialize_bin_with(&field.attributes);
+        let field_serializer = crate::shared::attrs_serialize_bin_with(&field.attributes);
 
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(body, "let proxy: {} = Into::into(&self.{});", proxy, n);

--- a/derive/src/serde_bin.rs
+++ b/derive/src/serde_bin.rs
@@ -41,6 +41,9 @@ pub fn derive_ser_bin_struct(struct_: &Struct) -> TokenStream {
     let (generic_w_bounds, generic_no_bounds) = struct_bounds_strings(struct_, "SerBin");
 
     for field in &struct_.fields {
+        let field_name: &String = field.field_name.as_ref().unwrap();
+        let field_serializer = shared::attrs_serialize_bin_with(&field.attributes);
+
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(
                 body,
@@ -48,12 +51,20 @@ pub fn derive_ser_bin_struct(struct_: &Struct) -> TokenStream {
                 proxy,
                 field.field_name.as_ref().unwrap()
             );
-            l!(body, "proxy.ser_bin(s);");
+            l!(
+                body,
+                &(field_serializer
+                    .map(|serializer: String| format!("{}(&proxy, s);", serializer))
+                    .as_ref()
+                    .map(|s| s.as_str())
+                    .unwrap_or_else(|| "proxy.ser_bin(s);"))
+            )
         } else {
             l!(
                 body,
-                "self.{}.ser_bin(s);",
-                field.field_name.as_ref().unwrap()
+                &field_serializer
+                    .map(|serializer: String| format!("{}(&self.{}, s);", serializer, field_name))
+                    .unwrap_or_else(|| format!("self.{}.ser_bin(s);", field_name))
             );
         }
     }
@@ -80,11 +91,25 @@ pub fn derive_ser_bin_struct_unnamed(struct_: &Struct) -> TokenStream {
     let (generic_w_bounds, generic_no_bounds) = struct_bounds_strings(struct_, "SerBin");
 
     for (n, field) in struct_.fields.iter().enumerate() {
+        let field_serializer = shared::attrs_serialize_bin_with(&field.attributes);
+
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(body, "let proxy: {} = Into::into(&self.{});", proxy, n);
-            l!(body, "proxy.ser_bin(s);");
+            l!(
+                body,
+                &(field_serializer
+                    .map(|serializer: String| format!("{}(&proxy, s);", serializer))
+                    .as_ref()
+                    .map(|s| s.as_str())
+                    .unwrap_or_else(|| "proxy.ser_bin(s);"))
+            );
         } else {
-            l!(body, "self.{}.ser_bin(s);", n);
+            l!(
+                body,
+                &field_serializer
+                    .map(|serializer: String| format!("{}(&self.{}, s);", serializer, n))
+                    .unwrap_or_else(|| format!("self.{}.ser_bin(s);", n))
+            );
         }
     }
     format!(
@@ -110,16 +135,24 @@ pub fn derive_de_bin_struct(struct_: &Struct) -> TokenStream {
     let (generic_w_bounds, generic_no_bounds) = struct_bounds_strings(struct_, "DeBin");
 
     for field in &struct_.fields {
+        let de_bin_with = shared::attrs_deserialize_bin_with(&field.attributes)
+            .map(|with| format!("{}(o, d)", with));
+        let ref de_bin_expr: &str = de_bin_with
+            .as_ref()
+            .map(|w| w.as_str())
+            .unwrap_or("DeBin::de_bin(o, d)");
+
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(body, "{}: {{", field.field_name.as_ref().unwrap());
-            l!(body, "let proxy: {} = DeBin::de_bin(o, d)?;", proxy);
+            l!(body, "let proxy: {} = {}?;", proxy, de_bin_expr);
             l!(body, "Into::into(&proxy)");
             l!(body, "},")
         } else {
             l!(
                 body,
-                "{}: DeBin::de_bin(o, d)?,",
-                field.field_name.as_ref().unwrap()
+                "{}: {}?,",
+                field.field_name.as_ref().unwrap(),
+                de_bin_expr
             );
         }
     }
@@ -149,13 +182,20 @@ pub fn derive_de_bin_struct_unnamed(struct_: &Struct) -> TokenStream {
     let (generic_w_bounds, generic_no_bounds) = struct_bounds_strings(struct_, "DeBin");
 
     for (n, field) in struct_.fields.iter().enumerate() {
+        let de_bin_with = shared::attrs_deserialize_bin_with(&field.attributes)
+            .map(|with| format!("{}(o, d)", with));
+        let ref de_bin_expr: &str = de_bin_with
+            .as_ref()
+            .map(|w| w.as_str())
+            .unwrap_or("DeBin::de_bin(o, d)");
+
         if let Some(proxy) = crate::shared::attrs_proxy(&field.attributes) {
             l!(body, "{}: {{", n);
-            l!(body, "let proxy: {} = DeBin::de_bin(o, d)?;", proxy);
+            l!(body, "let proxy: {} = {}?;", proxy, de_bin_expr);
             l!(body, "Into::into(&proxy)");
             l!(body, "},")
         } else {
-            l!(body, "{}: DeBin::de_bin(o, d)?,", n);
+            l!(body, "{}: {}?,", n, de_bin_expr);
         }
     }
 

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -62,6 +62,50 @@ pub fn attrs_default_with(attributes: &[crate::parse::Attribute]) -> Option<Stri
     })
 }
 
+#[cfg(any(feature = "json"))]
+pub fn attrs_deserialize_json_with(attributes: &[crate::parse::Attribute]) -> Option<String> {
+    attributes.iter().find_map(|attr| {
+        if attr.tokens.len() == 2 && attr.tokens[0] == "deserialize_json_with" {
+            Some(attr.tokens[1].clone())
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(any(feature = "json"))]
+pub fn attrs_serialize_json_with(attributes: &[crate::parse::Attribute]) -> Option<String> {
+    attributes.iter().find_map(|attr| {
+        if attr.tokens.len() == 2 && attr.tokens[0] == "serialize_json_with" {
+            Some(attr.tokens[1].clone())
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(any(feature = "binary"))]
+pub fn attrs_deserialize_bin_with(attributes: &[crate::parse::Attribute]) -> Option<String> {
+    attributes.iter().find_map(|attr| {
+        if attr.tokens.len() == 2 && attr.tokens[0] == "deserialize_bin_with" {
+            Some(attr.tokens[1].clone())
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(any(feature = "binary"))]
+pub fn attrs_serialize_bin_with(attributes: &[crate::parse::Attribute]) -> Option<String> {
+    attributes.iter().find_map(|attr| {
+        if attr.tokens.len() == 2 && attr.tokens[0] == "serialize_bin_with" {
+            Some(attr.tokens[1].clone())
+        } else {
+            None
+        }
+    })
+}
+
 #[cfg(feature = "json")]
 pub fn attrs_transparent(attributes: &[crate::parse::Attribute]) -> bool {
     attributes

--- a/tests/bin.rs
+++ b/tests/bin.rs
@@ -6,7 +6,7 @@ use std::{array, sync::atomic::AtomicBool};
 
 use alloc::collections::{BTreeMap, BTreeSet, LinkedList};
 
-use nanoserde::{DeBin, SerBin};
+use nanoserde::{DeBin, DeBinErr, SerBin};
 
 #[test]
 fn binary() {
@@ -137,6 +137,63 @@ fn field_ignore_self_bound() {
     let bytes = SerBin::serialize_bin(&test);
     let deser: DeSerializable = DeBin::deserialize_bin(&bytes).unwrap();
     assert_eq!(foo_base, deser.foo);
+}
+
+#[test]
+fn field_custom_serialize() {
+    fn custom_serializer(x: &i32, output: &mut Vec<u8>) {
+        let mut as_bytes = Vec::new();
+        as_bytes.append(&mut [99, 99, 99, 99].to_vec());
+        as_bytes.append(&mut x.to_le_bytes().to_vec());
+        as_bytes.append(&mut [44, 44, 44, 44].to_vec());
+        output.append(&mut as_bytes)
+    }
+
+    fn custom_deserializer(offset: &mut usize, input: &[u8]) -> Result<i32, DeBinErr> {
+        let header = input[*offset..*offset + 4].as_ref();
+        let content = [
+            input[*offset + 4],
+            input[*offset + 5],
+            input[*offset + 6],
+            input[*offset + 7],
+        ];
+        let footer = input[*offset + 8..*offset + 12].as_ref();
+
+        if header.iter().any(|&x| x != 99) || footer.iter().any(|&x| x != 44) {
+            return Err(DeBinErr {
+                o: *offset,
+                l: 0,
+                s: 0,
+            });
+        }
+
+        *offset += 12;
+        Ok(i32::from_le_bytes(content))
+    }
+
+    #[derive(DeBin, SerBin, PartialEq, Debug)]
+    pub struct Test {
+        #[nserde(
+            serialize_bin_with = "custom_serializer",
+            deserialize_bin_with = "custom_deserializer"
+        )]
+        x: i32,
+        y: i32,
+    }
+    let test = Test { x: 1, y: 2 };
+
+    let bytes = SerBin::serialize_bin(&test);
+    assert_eq!(
+        bytes,
+        vec![
+            99, 99, 99, 99, // x - custom header
+            1, 0, 0, 0, // x - content of field
+            44, 44, 44, 44, // x- custom footer
+            2, 0, 0, 0 // y - default serialization
+        ]
+    );
+    let test_deserialized = DeBin::deserialize_bin(&bytes).unwrap();
+    assert_eq!(test, test_deserialized);
 }
 
 #[test]


### PR DESCRIPTION
This change adds support for nanoserde's analogs for serde's [`serialize_with`](https://serde.rs/field-attrs.html#serialize_with) and [`deserialize_with`](https://serde.rs/field-attrs.html#skip_deserializing) field attributes.

nanoserde is designed to translate directly between the serialized format the in-memory representation. This requires splitting the attribute into separate attributes for each of the target formats, instead of the singular `deserialize_with` or `serialize_with`.

---

For context, I'm porting a library from `serde` to `nanoserde` to try to reduce binary size in a game I'm working on, and to facilitate that, I found it handy to bridge some of the feature gap between the libraries.  
Let me know if you're okay with contributions in this vein. I generally like to upstream new features when maintainers are interested.