### PR TITLE
v0.2 housekeeping: non_exhaustive all the things

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanoserde"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 authors = ["makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = """
@@ -30,4 +30,4 @@ toml = []
 std = []
 
 [dependencies]
-nanoserde-derive = { path = "derive", version = "=0.2.0-beta.1", optional = true }
+nanoserde-derive = { path = "derive", version = "=0.2.0-beta.2", optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanoserde-derive"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 authors = ["Makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
 edition = "2018"
 description = "Fork of makepad-tinyserde derive without any external dependencies"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 extern crate proc_macro;
 
+#[cfg(any(feature = "json", feature = "ron", feature = "binary"))]
 #[macro_use]
 mod shared;
 
@@ -21,6 +22,7 @@ mod serde_json;
 #[cfg(feature = "json")]
 use crate::serde_json::*;
 
+#[cfg(any(feature = "json", feature = "ron", feature = "binary"))]
 mod parse;
 
 #[cfg(feature = "binary")]

--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -135,6 +135,7 @@ pub struct Struct {
     pub named: bool,
     pub fields: Vec<Field>,
     pub attributes: Vec<Attribute>,
+    #[cfg_attr(feature = "ron", allow(unused))]
     pub generics: Vec<Generic>,
 }
 
@@ -143,6 +144,7 @@ pub struct Enum {
     pub name: String,
     pub variants: Vec<Field>,
     pub attributes: Vec<Attribute>,
+    #[cfg_attr(feature = "ron", allow(unused))]
     pub generics: Vec<Generic>,
 }
 

--- a/derive/src/serde_bin.rs
+++ b/derive/src/serde_bin.rs
@@ -325,7 +325,7 @@ pub fn derive_de_bin_enum(enum_: &Enum) -> TokenStream {
                 let id: u16 = DeBin::de_bin(o,d)?;
                 Ok(match id {{
                     {}
-                    _ => return ::core::result::Result::Err(nanoserde::DeBinErr{{o:*o, l:0, s:d.len()}})
+                    _ => return ::core::result::Result::Err(nanoserde::DeBinErr::new(*o, 0, d.len()))
                 }})
             }}
         }}", generic_w_bounds,enum_.name,generic_no_bounds, r)

--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -60,12 +60,16 @@ pub fn derive_ser_json_struct(struct_: &Struct) -> TokenStream {
                 let proxy_attr = crate::shared::attrs_proxy(&field.attributes);
                 let struct_null_on_none = shared::attrs_serialize_none_as_null(&struct_.attributes);
                 let field_null_on_none = shared::attrs_serialize_none_as_null(&field.attributes);
-                let null_on_none = (field_null_on_none || struct_null_on_none) && proxy_attr.is_none();
-                let field_header = &format!("if first_field_was_serialized {{
+                let null_on_none =
+                    (field_null_on_none || struct_null_on_none) && proxy_attr.is_none();
+                let field_header = &format!(
+                    "if first_field_was_serialized {{
                                                  s.conl();
                                              }};
                                              first_field_was_serialized = true;
-                                             s.field(d+1, \"{}\");", json_fieldname);
+                                             s.field(d+1, \"{}\");",
+                    json_fieldname
+                );
                 l!(
                     s,
                     "{}

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -1,8 +1,9 @@
-use alloc::{
-    format,
-    string::{String, ToString},
-    vec::Vec,
-};
+#![cfg(any(feature = "json", feature = "ron", feature = "binary"))]
+
+#[cfg(any(feature = "json", feature = "binary"))]
+use alloc::{format, string::ToString, vec::Vec};
+
+use alloc::string::String;
 
 #[cfg(any(feature = "binary", feature = "json"))]
 use crate::parse::{Enum, Struct};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
 //! For `#[nserde(..)]` supported attributes for each format check [Features support matrix](https://github.com/not-fl3/nanoserde#features-support-matrix)
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(error_in_core))]
 
 extern crate alloc;
 

--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -61,10 +61,17 @@ pub trait DeBin: Sized {
 
 /// The error message when failing to deserialize from raw bytes.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct DeBinErr {
     pub o: usize,
     pub l: usize,
     pub s: usize,
+}
+
+impl DeBinErr {
+    pub fn new(o: usize, l: usize, s: usize) -> Self {
+        Self { o, l, s }
+    }
 }
 
 impl core::fmt::Debug for DeBinErr {

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -1,6 +1,6 @@
 use core::str::Chars;
 
-// remove this after 1.81 is live
+// remove this after 1.81 is msrv
 #[cfg(not(feature = "std"))]
 use core::error::Error;
 #[cfg(feature = "std")]
@@ -13,11 +13,16 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 /// The internal state of a JSON serialization.
+#[non_exhaustive]
 pub struct SerJsonState {
     pub out: String,
 }
 
 impl SerJsonState {
+    pub fn new(out: String) -> Self {
+        Self { out }
+    }
+
     pub fn indent(&mut self, _d: usize) {
         //for _ in 0..d {
         //    self.out.push_str("    ");
@@ -67,7 +72,7 @@ pub trait SerJson {
     ///
     /// ```rust
     /// # use nanoserde::*;
-    /// let mut s = SerJsonState { out: String::new() };
+    /// let mut s = SerJsonState::new(String::new());
     /// 42u32.ser_json(0, &mut s);
     /// assert_eq!(s.out, "42");
     /// ```
@@ -103,6 +108,7 @@ pub trait DeJson: Sized {
 
 /// A JSON parsed token.
 #[derive(PartialEq, Debug)]
+#[non_exhaustive]
 pub enum DeJsonTok {
     Str,
     Char(char),
@@ -130,6 +136,7 @@ impl Default for DeJsonTok {
 
 /// The internal state of a JSON deserialization.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct DeJsonState {
     pub cur: char,
     pub tok: DeJsonTok,
@@ -142,6 +149,7 @@ pub struct DeJsonState {
 
 /// The error message when failing to deserialize a JSON string.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct DeJsonErr {
     pub msg: String,
     pub line: usize,

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -127,6 +127,7 @@ impl Default for DeRonTok {
 
 /// The internal state of a RON deserialization.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct DeRonState {
     pub cur: char,
     pub tok: DeRonTok,
@@ -139,6 +140,7 @@ pub struct DeRonState {
 
 /// The error message when failing to deserialize a RON string.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct DeRonErr {
     pub msg: String,
     pub line: usize,

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -55,6 +55,7 @@ macro_rules! ident_term_chars {
 /// assert_eq!(parsed["Section.value"], Toml::Num(1.));
 /// ```
 #[derive(Default)]
+#[non_exhaustive]
 pub struct TomlParser {
     cur: char,
     line: usize,
@@ -63,6 +64,7 @@ pub struct TomlParser {
 
 /// A TOML parsed token.
 #[derive(PartialEq, Debug)]
+#[non_exhaustive]
 pub enum TomlTok {
     Ident(String),
     Str(String),
@@ -197,6 +199,7 @@ impl Toml {
 
 /// The error message when failing to parse a TOML string.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct TomlErr {
     pub msg: String,
     pub line: usize,


### PR DESCRIPTION
Fixed a handful of build warnings that show up in CI, and put `non_exhaustive` on most public structs so that they can be adjusted without breaking changes in future