### PR TITLE
fix hundreds of clippy warnings

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -30,19 +30,17 @@ mod parse;
 pub fn derive_ser_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
-    if let Some(proxy) = shared::attrs_proxy(&input.attributes()) {
-        return derive_ser_bin_proxy(&proxy, &input.name());
+    if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
+        return derive_ser_bin_proxy(&proxy, input.name());
     }
 
     // ok we have an ident, its either a struct or a enum
-    let ts = match &input {
+    match &input {
         parse::Data::Struct(struct_) if struct_.named => derive_ser_bin_struct(struct_),
         parse::Data::Struct(struct_) => derive_ser_bin_struct_unnamed(struct_),
         parse::Data::Enum(enum_) => derive_ser_bin_enum(enum_),
         _ => unimplemented!("Only structs and enums are supported"),
-    };
-
-    ts
+    }
 }
 
 #[cfg(feature = "binary")]
@@ -50,20 +48,18 @@ pub fn derive_ser_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 pub fn derive_de_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
-    if let Some(proxy) = shared::attrs_proxy(&input.attributes()) {
-        return derive_de_bin_proxy(&proxy, &input.name());
+    if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
+        return derive_de_bin_proxy(&proxy, input.name());
     }
 
     // ok we have an ident, its either a struct or a enum
-    let ts = match &input {
+    match &input {
         parse::Data::Struct(struct_) if struct_.named => derive_de_bin_struct(struct_),
         parse::Data::Struct(struct_) => derive_de_bin_struct_unnamed(struct_),
         parse::Data::Enum(enum_) => derive_de_bin_enum(enum_),
 
         _ => unimplemented!("Only structs and enums are supported"),
-    };
-
-    ts
+    }
 }
 
 #[cfg(feature = "ron")]
@@ -71,19 +67,17 @@ pub fn derive_de_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 pub fn derive_ser_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
-    if let Some(proxy) = shared::attrs_proxy(&input.attributes()) {
-        return derive_ser_ron_proxy(&proxy, &input.name());
+    if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
+        return derive_ser_ron_proxy(&proxy, input.name());
     }
 
     // ok we have an ident, its either a struct or a enum
-    let ts = match &input {
+    match &input {
         parse::Data::Struct(struct_) if struct_.named => derive_ser_ron_struct(struct_),
         parse::Data::Struct(struct_) => derive_ser_ron_struct_unnamed(struct_),
         parse::Data::Enum(enum_) => derive_ser_ron_enum(enum_),
         _ => unimplemented!("Only structs and enums are supported"),
-    };
-
-    ts
+    }
 }
 
 #[cfg(feature = "ron")]
@@ -91,19 +85,17 @@ pub fn derive_ser_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 pub fn derive_de_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
-    if let Some(proxy) = shared::attrs_proxy(&input.attributes()) {
-        return derive_de_ron_proxy(&proxy, &input.name());
+    if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
+        return derive_de_ron_proxy(&proxy, input.name());
     }
 
     // ok we have an ident, its either a struct or a enum
-    let ts = match &input {
+    match &input {
         parse::Data::Struct(struct_) if struct_.named => derive_de_ron_struct(struct_),
         parse::Data::Struct(struct_) => derive_de_ron_struct_unnamed(struct_),
         parse::Data::Enum(enum_) => derive_de_ron_enum(enum_),
         _ => unimplemented!("Only structs and enums are supported"),
-    };
-
-    ts
+    }
 }
 
 #[cfg(feature = "json")]
@@ -111,19 +103,17 @@ pub fn derive_de_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 pub fn derive_ser_json(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
-    if let Some(proxy) = shared::attrs_proxy(&input.attributes()) {
-        return derive_ser_json_proxy(&proxy, &input.name());
+    if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
+        return derive_ser_json_proxy(&proxy, input.name());
     }
 
     // ok we have an ident, its either a struct or a enum
-    let ts = match &input {
+    match &input {
         parse::Data::Struct(struct_) if struct_.named => derive_ser_json_struct(struct_),
         parse::Data::Struct(struct_) => derive_ser_json_struct_unnamed(struct_),
         parse::Data::Enum(enum_) => derive_ser_json_enum(enum_),
         _ => unimplemented!(""),
-    };
-
-    ts
+    }
 }
 
 #[cfg(feature = "json")]
@@ -131,17 +121,15 @@ pub fn derive_ser_json(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 pub fn derive_de_json(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
-    if let Some(proxy) = shared::attrs_proxy(&input.attributes()) {
-        return derive_de_json_proxy(&proxy, &input.name());
+    if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
+        return derive_de_json_proxy(&proxy, input.name());
     }
 
     // ok we have an ident, its either a struct or a enum
-    let ts = match &input {
+    match &input {
         parse::Data::Struct(struct_) if struct_.named => derive_de_json_struct(struct_),
         parse::Data::Struct(struct_) => derive_de_json_struct_unnamed(struct_),
         parse::Data::Enum(enum_) => derive_de_json_enum(enum_),
         parse::Data::Union(_) => unimplemented!("Unions are not supported"),
-    };
-
-    ts
+    }
 }

--- a/derive/src/serde_bin.rs
+++ b/derive/src/serde_bin.rs
@@ -219,7 +219,7 @@ pub fn derive_ser_bin_enum(enum_: &Enum) -> TokenStream {
                 ..
             } => {
                 l!(r, "Self::{} {{", ident);
-                for (_, f) in contents.fields.iter().enumerate() {
+                for f in contents.fields.iter() {
                     l!(
                         r,
                         "{}, ",
@@ -229,7 +229,7 @@ pub fn derive_ser_bin_enum(enum_: &Enum) -> TokenStream {
 
                 l!(r, "} => {");
                 l!(r, "{}.ser_bin(s);", lit);
-                for (_, f) in contents.fields.iter().enumerate() {
+                for f in contents.fields.iter() {
                     l!(
                         r,
                         "{}.ser_bin(s);",

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -106,7 +106,7 @@ pub(crate) fn struct_bounds_strings(struct_: &Struct, bound_name: &str) -> (Stri
         generic_no_bounds += ", ";
     }
     generic_no_bounds += ">";
-    return (generic_w_bounds, generic_no_bounds);
+    (generic_w_bounds, generic_no_bounds)
 }
 
 #[cfg(any(feature = "binary", feature = "json"))]
@@ -131,5 +131,5 @@ pub(crate) fn enum_bounds_strings(enum_: &Enum, bound_name: &str) -> (String, St
         generic_no_bounds += ", ";
     }
     generic_no_bounds += ">";
-    return (generic_w_bounds, generic_no_bounds);
+    (generic_w_bounds, generic_no_bounds)
 }

--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -107,7 +107,7 @@ macro_rules! impl_ser_de_bin_for {
                 if *o + l > d.len() {
                     return Err(DeBinErr {
                         o: *o,
-                        l: l,
+                        l,
                         s: d.len(),
                     });
                 }

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -98,7 +98,7 @@ pub trait DeRon: Sized {
 }
 
 /// A RON parsed token.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Default)]
 pub enum DeRonTok {
     Ident,
     Str,
@@ -115,14 +115,9 @@ pub enum DeRonTok {
     BlockOpen,
     BlockClose,
     Comma,
+    #[default]
     Bof,
     Eof,
-}
-
-impl Default for DeRonTok {
-    fn default() -> Self {
-        DeRonTok::Bof
-    }
 }
 
 /// The internal state of a RON deserialization.
@@ -480,11 +475,7 @@ impl DeRonState {
                                 self.next(i);
                                 break;
                             }
-                            if self.cur == '*' {
-                                last_star = true
-                            } else {
-                                last_star = false
-                            }
+                            last_star = self.cur == '*';
                             self.next(i);
                         }
                     } else {
@@ -745,15 +736,15 @@ macro_rules! impl_ser_de_ron_float {
     };
 }
 
-impl_ser_de_ron_unsigned!(usize, core::u64::MAX);
-impl_ser_de_ron_unsigned!(u64, core::u64::MAX);
-impl_ser_de_ron_unsigned!(u32, core::u32::MAX);
-impl_ser_de_ron_unsigned!(u16, core::u16::MAX);
-impl_ser_de_ron_unsigned!(u8, core::u8::MAX);
-impl_ser_de_ron_signed!(i64, core::i64::MIN, core::i64::MAX);
-impl_ser_de_ron_signed!(i32, core::i32::MIN, core::i32::MAX);
-impl_ser_de_ron_signed!(i16, core::i16::MIN, core::i16::MAX);
-impl_ser_de_ron_signed!(i8, core::i8::MIN, core::i8::MAX);
+impl_ser_de_ron_unsigned!(usize, u64::MAX);
+impl_ser_de_ron_unsigned!(u64, u64::MAX);
+impl_ser_de_ron_unsigned!(u32, u32::MAX);
+impl_ser_de_ron_unsigned!(u16, u16::MAX);
+impl_ser_de_ron_unsigned!(u8, u8::MAX);
+impl_ser_de_ron_signed!(i64, i64::MIN, i64::MAX);
+impl_ser_de_ron_signed!(i32, i32::MIN, i32::MAX);
+impl_ser_de_ron_signed!(i16, i16::MIN, i16::MAX);
+impl_ser_de_ron_signed!(i8, i8::MIN, i8::MAX);
 impl_ser_de_ron_float!(f64);
 impl_ser_de_ron_float!(f32);
 
@@ -799,7 +790,7 @@ impl DeRon for bool {
     fn de_ron(s: &mut DeRonState, i: &mut Chars) -> Result<bool, DeRonErr> {
         let val = s.as_bool()?;
         s.next_tok(i)?;
-        return Ok(val);
+        Ok(val)
     }
 }
 
@@ -843,7 +834,7 @@ impl DeRon for String {
     fn de_ron(s: &mut DeRonState, i: &mut Chars) -> Result<String, DeRonErr> {
         let val = s.as_string()?;
         s.next_tok(i)?;
-        return Ok(val);
+        Ok(val)
     }
 }
 
@@ -887,7 +878,7 @@ where
 {
     fn ser_ron(&self, d: usize, s: &mut SerRonState) {
         s.out.push('[');
-        if self.len() > 0 {
+        if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
                 s.indent(d + 1);
@@ -925,7 +916,7 @@ where
 {
     fn ser_ron(&self, d: usize, s: &mut SerRonState) {
         s.out.push('[');
-        if self.len() > 0 {
+        if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
                 s.indent(d + 1);
@@ -962,7 +953,7 @@ where
 {
     fn ser_ron(&self, d: usize, s: &mut SerRonState) {
         s.out.push('[');
-        if self.len() > 0 {
+        if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
                 s.indent(d + 1);
@@ -1199,7 +1190,7 @@ where
         for (k, v) in self {
             s.indent(d + 1);
             k.ser_ron(d + 1, s);
-            s.out.push_str(":");
+            s.out.push(':');
             v.ser_ron(d + 1, s);
             s.conl();
         }
@@ -1239,7 +1230,7 @@ where
         for (k, v) in self {
             s.indent(d + 1);
             k.ser_ron(d + 1, s);
-            s.out.push_str(":");
+            s.out.push(':');
             v.ser_ron(d + 1, s);
             s.conl();
         }

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -340,6 +340,7 @@ impl TomlParser {
         Ok(true)
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn to_val(&mut self, tok: TomlTok, i: &mut Chars) -> Result<Toml, TomlErr> {
         match tok {
             TomlTok::BlockOpen => {
@@ -360,12 +361,8 @@ impl TomlParser {
             TomlTok::I64(v) => Ok(Toml::Num(v as f64)),
             TomlTok::F64(v) => Ok(Toml::Num(v)),
             TomlTok::Bool(v) => Ok(Toml::Bool(v)),
-            TomlTok::Nan(v) => Ok(Toml::Num(if v { -core::f64::NAN } else { core::f64::NAN })),
-            TomlTok::Inf(v) => Ok(Toml::Num(if v {
-                -core::f64::INFINITY
-            } else {
-                core::f64::INFINITY
-            })),
+            TomlTok::Nan(v) => Ok(Toml::Num(if v { -f64::NAN } else { f64::NAN })),
+            TomlTok::Inf(v) => Ok(Toml::Num(if v { -f64::INFINITY } else { f64::INFINITY })),
             TomlTok::Date(v) => Ok(Toml::Date(v)),
             _ => Err(self.err_token(tok)),
         }
@@ -474,7 +471,7 @@ impl TomlParser {
                     }
                     let escaped_string = braces == 3;
                     loop {
-                        if self.cur == '"' && escaped_string == false {
+                        if self.cur == '"' && !escaped_string {
                             break;
                         }
                         if self.cur == '"' && escaped_string {


### PR DESCRIPTION
Single instances of: `clippy::wrong_self_convention`, `clippy::enum_variant_names` and `clippy::vec_box` are allowed, since the solutions albeit potentially simple are nevertheless non-straight forward.