### PR TITLE
bump edition to 2021 and set msrv to 1.71.1

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -2,7 +2,8 @@
 name = "nanoserde-derive"
 version = "0.2.0-beta.2"
 authors = ["Makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.71.1"
 description = "Fork of makepad-tinyserde derive without any external dependencies"
 license = "MIT"
 


### PR DESCRIPTION
- msrv determined using cargo-msrv.

This would have to be updated for example to 1.81.0 in order to support `core::Error` (as noted in the source code).

EDIT: Another option would be to add a new feature (e.g. `msrv1_81`)