### PR TITLE
fix `needless_borrow` warnings in unsafe code

### DIFF
--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -439,7 +439,7 @@ where
 
         // waiting for array_assume_init or core::array::map optimizations
         // https://github.com/rust-lang/rust/issues/61956
-        Ok(unsafe { (&*(&to as *const _ as *const MaybeUninit<_>)).assume_init_read() })
+        Ok(unsafe { (*(&to as *const _ as *const MaybeUninit<_>)).assume_init_read() })
     }
 }
 

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -1056,7 +1056,7 @@ where
         // https://github.com/rust-lang/rust/issues/61956
         // initializing before block close so that drop will run automatically if err encountered there
         let initialized =
-            unsafe { (&*(&to as *const _ as *const MaybeUninit<_>)).assume_init_read() };
+            unsafe { (*(&to as *const _ as *const MaybeUninit<_>)).assume_init_read() };
         o.paren_close(d)?;
 
         Ok(initialized)


### PR DESCRIPTION
These are the fixes related to unsafe code, extracted from #119.

BTW I noticed in serde_json the equivalent code was already like that. So now it's all done the same way.