### PR TITLE
bump edition to 2021 and fix msrv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = """Serialization library with zero dependencies.
 Supports Binary, JSON, RON and TOML."""
-edition = "2018"
+edition = "2021"
+rust-version = "1.71.1"
 repository = "https://github.com/not-fl3/nanoserde"
 
 [features]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "nanoserde-derive"
 version = "0.2.0-beta.2"
 authors = ["Makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
 edition = "2021"
-rust-version = "1.71.1"
+rust-version = "1.78.0"
 description = "Fork of makepad-tinyserde derive without any external dependencies"
 license = "MIT"
 


### PR DESCRIPTION
I just noticed I missed a couple of things in #120, this PR fixes it.

1.71.1 is `nanoserde` msrv without optional macro crate, and 1.78.0 is `nanoserde-derive` msrv.