### PR TITLE
Use absolute paths in derive macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For more examples take a look at [tests](/tests)
 | container attribute: `#[nserde(rename = "")]`             | yes    | yes   | yes    | no    |
 | container attribute: `#[nserde(proxy = "")]`              | yes    | yes   | no     | no    |
 | container attribute: `#[nserde(transparent)]`             | yes    | no    | no     | no    |
+| container attribute: `#[nserde(crate = "")]`              | yes    | yes   | yes    | no    |
 
 ## Crate features:
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -30,15 +30,17 @@ mod parse;
 pub fn derive_ser_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
+    let crate_name = shared::attrs_crate(input.attributes()).unwrap_or("nanoserde");
+
     if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
-        return derive_ser_bin_proxy(&proxy, input.name());
+        return derive_ser_bin_proxy(&proxy, input.name(), crate_name);
     }
 
     // ok we have an ident, its either a struct or a enum
     match &input {
-        parse::Data::Struct(struct_) if struct_.named => derive_ser_bin_struct(struct_),
-        parse::Data::Struct(struct_) => derive_ser_bin_struct_unnamed(struct_),
-        parse::Data::Enum(enum_) => derive_ser_bin_enum(enum_),
+        parse::Data::Struct(struct_) if struct_.named => derive_ser_bin_struct(struct_, crate_name),
+        parse::Data::Struct(struct_) => derive_ser_bin_struct_unnamed(struct_, crate_name),
+        parse::Data::Enum(enum_) => derive_ser_bin_enum(enum_, crate_name),
         _ => unimplemented!("Only structs and enums are supported"),
     }
 }
@@ -48,15 +50,17 @@ pub fn derive_ser_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 pub fn derive_de_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
+    let crate_name = shared::attrs_crate(input.attributes()).unwrap_or("nanoserde");
+
     if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
-        return derive_de_bin_proxy(&proxy, input.name());
+        return derive_de_bin_proxy(&proxy, input.name(), crate_name);
     }
 
     // ok we have an ident, its either a struct or a enum
     match &input {
-        parse::Data::Struct(struct_) if struct_.named => derive_de_bin_struct(struct_),
-        parse::Data::Struct(struct_) => derive_de_bin_struct_unnamed(struct_),
-        parse::Data::Enum(enum_) => derive_de_bin_enum(enum_),
+        parse::Data::Struct(struct_) if struct_.named => derive_de_bin_struct(struct_, crate_name),
+        parse::Data::Struct(struct_) => derive_de_bin_struct_unnamed(struct_, crate_name),
+        parse::Data::Enum(enum_) => derive_de_bin_enum(enum_, crate_name),
 
         _ => unimplemented!("Only structs and enums are supported"),
     }
@@ -67,15 +71,17 @@ pub fn derive_de_bin(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 pub fn derive_ser_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
+    let crate_name = shared::attrs_crate(input.attributes()).unwrap_or("nanoserde");
+
     if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
-        return derive_ser_ron_proxy(&proxy, input.name());
+        return derive_ser_ron_proxy(&proxy, input.name(), crate_name);
     }
 
     // ok we have an ident, its either a struct or a enum
     match &input {
-        parse::Data::Struct(struct_) if struct_.named => derive_ser_ron_struct(struct_),
-        parse::Data::Struct(struct_) => derive_ser_ron_struct_unnamed(struct_),
-        parse::Data::Enum(enum_) => derive_ser_ron_enum(enum_),
+        parse::Data::Struct(struct_) if struct_.named => derive_ser_ron_struct(struct_, crate_name),
+        parse::Data::Struct(struct_) => derive_ser_ron_struct_unnamed(struct_, crate_name),
+        parse::Data::Enum(enum_) => derive_ser_ron_enum(enum_, crate_name),
         _ => unimplemented!("Only structs and enums are supported"),
     }
 }
@@ -85,15 +91,17 @@ pub fn derive_ser_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 pub fn derive_de_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
+    let crate_name = shared::attrs_crate(input.attributes()).unwrap_or("nanoserde");
+
     if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
-        return derive_de_ron_proxy(&proxy, input.name());
+        return derive_de_ron_proxy(&proxy, input.name(), crate_name);
     }
 
     // ok we have an ident, its either a struct or a enum
     match &input {
-        parse::Data::Struct(struct_) if struct_.named => derive_de_ron_struct(struct_),
-        parse::Data::Struct(struct_) => derive_de_ron_struct_unnamed(struct_),
-        parse::Data::Enum(enum_) => derive_de_ron_enum(enum_),
+        parse::Data::Struct(struct_) if struct_.named => derive_de_ron_struct(struct_, crate_name),
+        parse::Data::Struct(struct_) => derive_de_ron_struct_unnamed(struct_, crate_name),
+        parse::Data::Enum(enum_) => derive_de_ron_enum(enum_, crate_name),
         _ => unimplemented!("Only structs and enums are supported"),
     }
 }
@@ -103,15 +111,19 @@ pub fn derive_de_ron(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 pub fn derive_ser_json(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
+    let crate_name = shared::attrs_crate(input.attributes()).unwrap_or("nanoserde");
+
     if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
-        return derive_ser_json_proxy(&proxy, input.name());
+        return derive_ser_json_proxy(&proxy, input.name(), crate_name);
     }
 
     // ok we have an ident, its either a struct or a enum
     match &input {
-        parse::Data::Struct(struct_) if struct_.named => derive_ser_json_struct(struct_),
-        parse::Data::Struct(struct_) => derive_ser_json_struct_unnamed(struct_),
-        parse::Data::Enum(enum_) => derive_ser_json_enum(enum_),
+        parse::Data::Struct(struct_) if struct_.named => {
+            derive_ser_json_struct(struct_, crate_name)
+        }
+        parse::Data::Struct(struct_) => derive_ser_json_struct_unnamed(struct_, crate_name),
+        parse::Data::Enum(enum_) => derive_ser_json_enum(enum_, crate_name),
         _ => unimplemented!(""),
     }
 }
@@ -121,15 +133,17 @@ pub fn derive_ser_json(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 pub fn derive_de_json(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
+    let crate_name = shared::attrs_crate(input.attributes()).unwrap_or("nanoserde");
+
     if let Some(proxy) = shared::attrs_proxy(input.attributes()) {
-        return derive_de_json_proxy(&proxy, input.name());
+        return derive_de_json_proxy(&proxy, input.name(), crate_name);
     }
 
     // ok we have an ident, its either a struct or a enum
     match &input {
-        parse::Data::Struct(struct_) if struct_.named => derive_de_json_struct(struct_),
-        parse::Data::Struct(struct_) => derive_de_json_struct_unnamed(struct_),
-        parse::Data::Enum(enum_) => derive_de_json_enum(enum_),
+        parse::Data::Struct(struct_) if struct_.named => derive_de_json_struct(struct_, crate_name),
+        parse::Data::Struct(struct_) => derive_de_json_struct_unnamed(struct_, crate_name),
+        parse::Data::Enum(enum_) => derive_de_json_enum(enum_, crate_name),
         parse::Data::Union(_) => unimplemented!("Unions are not supported"),
     }
 }

--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -13,7 +13,7 @@ use proc_macro::TokenStream;
 
 pub fn derive_ser_json_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
-        "impl SerJson for {} {{
+        "impl nanoserde::SerJson for {} {{
             fn ser_json(&self, d: usize, s: &mut nanoserde::SerJsonState) {{
                 let proxy: {} = self.into();
                 proxy.ser_json(d, s);
@@ -106,7 +106,7 @@ pub fn derive_ser_json_struct(struct_: &Struct) -> TokenStream {
 
     format!(
         "
-        impl{} SerJson for {}{} {{
+        impl{} nanoserde::SerJson for {}{} {{
             fn ser_json(&self, d: usize, s: &mut nanoserde::SerJsonState) {{
                 s.st_pre();
                 {}
@@ -222,7 +222,7 @@ pub fn derive_de_json_named(name: &str, defaults: bool, fields: &[Field]) -> Tok
         for (json_field_name, local_var) in matches.iter() {
             l!(
                 r,
-                "\"{}\" => {{s.next_colon(i) ?;{} = Some(DeJson::de_json(s, i) ?)}},",
+                "\"{}\" => {{s.next_colon(i) ?;{} = Some(nanoserde::DeJson::de_json(s, i) ?)}},",
                 json_field_name,
                 local_var
             );
@@ -249,10 +249,10 @@ pub fn derive_de_json_named(name: &str, defaults: bool, fields: &[Field]) -> Tok
 
 pub fn derive_de_json_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
-        "impl DeJson for {} {{
+        "impl nanoserde::DeJson for {} {{
             #[allow(clippy::ignored_unit_patterns)]
             fn de_json(s: &mut nanoserde::DeJsonState, i: &mut core::str::Chars) -> ::core::result::Result<Self, nanoserde::DeJsonErr> {{
-                let proxy: {} = DeJson::de_json(s, i)?;
+                let proxy: {} = nanoserde::DeJson::de_json(s, i)?;
                 ::core::result::Result::Ok(Into::into(&proxy))
             }}
         }}",
@@ -275,7 +275,7 @@ pub fn derive_de_json_struct(struct_: &Struct) -> TokenStream {
     let (generic_w_bounds, generic_no_bounds) = struct_bounds_strings(struct_, "DeJson");
 
     format!(
-        "impl{} DeJson for {}{} {{
+        "impl{} nanoserde::DeJson for {}{} {{
             #[allow(clippy::ignored_unit_patterns)]
             fn de_json(s: &mut nanoserde::DeJsonState, i: &mut core::str::Chars) -> ::core::result::Result<Self,
             nanoserde::DeJsonErr> {{
@@ -412,7 +412,7 @@ pub fn derive_ser_json_enum(enum_: &Enum) -> TokenStream {
 
     format!(
         "
-        impl SerJson for {} {{
+        impl nanoserde::SerJson for {} {{
             fn ser_json(&self, d: usize, s: &mut nanoserde::SerJsonState) {{
                 match self {{
                     {}
@@ -468,7 +468,7 @@ pub fn derive_de_json_enum(enum_: &Enum) -> TokenStream {
                 for _ in contents.iter() {
                     l!(
                         field_names,
-                        "{let r = DeJson::de_json(s,i)?;s.eat_comma_block(i)?;r},"
+                        "{let r = nanoserde::DeJson::de_json(s,i)?;s.eat_comma_block(i)?;r},"
                     );
                 }
                 l!(
@@ -486,7 +486,7 @@ pub fn derive_de_json_enum(enum_: &Enum) -> TokenStream {
     }
 
     let mut r = format!(
-        "impl{} DeJson for {}{} {{
+        "impl{} nanoserde::DeJson for {}{} {{
             #[allow(clippy::ignored_unit_patterns)]
             fn de_json(s: &mut nanoserde::DeJsonState, i: &mut core::str::Chars) -> ::core::result::Result<Self, nanoserde::DeJsonErr> {{
                 match s.tok {{",
@@ -568,7 +568,7 @@ pub fn derive_ser_json_struct_unnamed(struct_: &Struct) -> TokenStream {
 
     format!(
         "
-        impl{} SerJson for {}{} {{
+        impl{} nanoserde::SerJson for {}{} {{
             fn ser_json(&self, d: usize, s: &mut nanoserde::SerJsonState) {{
                 {}
             }}
@@ -592,7 +592,7 @@ pub fn derive_de_json_struct_unnamed(struct_: &Struct) -> TokenStream {
     let transparent = shared::attrs_transparent(&struct_.attributes);
 
     for _ in &struct_.fields {
-        l!(body, "{ let r = DeJson::de_json(s, i)?;");
+        l!(body, "{ let r = nanoserde::DeJson::de_json(s, i)?;");
         if struct_.fields.len() != 1 {
             l!(body, "  s.eat_comma_block(i)?;");
         }
@@ -620,7 +620,7 @@ pub fn derive_de_json_struct_unnamed(struct_: &Struct) -> TokenStream {
     };
 
     format! ("
-        impl{} DeJson for {}{} {{
+        impl{} nanoserde::DeJson for {}{} {{
             #[allow(clippy::ignored_unit_patterns)]
             fn de_json(s: &mut nanoserde::DeJsonState, i: &mut core::str::Chars) -> ::core::result::Result<Self,nanoserde::DeJsonErr> {{
                 {}

--- a/derive/src/serde_ron.rs
+++ b/derive/src/serde_ron.rs
@@ -10,7 +10,7 @@ use crate::shared;
 
 pub fn derive_ser_ron_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
-        "impl SerRon for {} {{
+        "impl nanoserde::SerRon for {} {{
             fn ser_ron(&self, d: usize, s: &mut nanoserde::SerRonState) {{
                 let proxy: {} = self.into();
                 proxy.ser_ron(d, s);
@@ -24,9 +24,9 @@ pub fn derive_ser_ron_proxy(proxy_type: &str, type_: &str) -> TokenStream {
 
 pub fn derive_de_ron_proxy(proxy_type: &str, type_: &str) -> TokenStream {
     format!(
-        "impl DeRon for {} {{
+        "impl nanoserde::DeRon for {} {{
             fn de_ron(_s: &mut nanoserde::DeRonState, i: &mut core::str::Chars) -> ::core::result::Result<Self, nanoserde::DeRonErr> {{
-                let proxy: {} = DeRon::deserialize_ron(i)?;
+                let proxy: {} = nanoserde::DeRon::deserialize_ron(i)?;
                 ::core::result::Result::Ok(Into::into(&proxy))
             }}
         }}",
@@ -72,7 +72,7 @@ pub fn derive_ser_ron_struct(struct_: &Struct) -> TokenStream {
 
     format!(
         "
-        impl SerRon for {} {{
+        impl nanoserde::SerRon for {} {{
             fn ser_ron(&self, d: usize, s: &mut nanoserde::SerRonState) {{
                 s.st_pre();
                 {}
@@ -102,7 +102,7 @@ pub fn derive_ser_ron_struct_unnamed(struct_: &Struct) -> TokenStream {
     }
     format!(
         "
-        impl SerRon for {} {{
+        impl nanoserde::SerRon for {} {{
             fn ser_ron(&self, d: usize, s: &mut nanoserde::SerRonState) {{
                 s.out.push('(');
                 {}
@@ -223,7 +223,7 @@ pub fn derive_de_ron_named(name: &String, fields: &Vec<Field>, attributes: &[Att
                 inner,
                 "\"{}\" => {{
                     s.next_colon(i)?;
-                    {} = Some(DeRon::de_ron(s, i)?)
+                    {} = Some(nanoserde::DeRon::de_ron(s, i)?)
                 }},",
                 ron_field_name,
                 local_var
@@ -274,7 +274,7 @@ pub fn derive_de_ron_struct(struct_: &Struct) -> TokenStream {
     );
 
     format!(
-        "impl DeRon for {} {{
+        "impl nanoserde::DeRon for {} {{
             fn de_ron(s: &mut nanoserde::DeRonState, i: &mut core::str::Chars) -> ::core::result::Result<Self,nanoserde::DeRonErr> {{
                 ::core::result::Result::Ok({})
             }}
@@ -290,7 +290,7 @@ pub fn derive_de_ron_struct_unnamed(struct_: &Struct) -> TokenStream {
         l!(
             body,
             "{{
-                let r = DeRon::de_ron(s, i)?;
+                let r = nanoserde::DeRon::de_ron(s, i)?;
                 s.eat_comma_paren(i)?;
                 r
             }},"
@@ -298,7 +298,7 @@ pub fn derive_de_ron_struct_unnamed(struct_: &Struct) -> TokenStream {
     }
 
     format! ("
-        impl DeRon for {} {{
+        impl nanoserde::DeRon for {} {{
             fn de_ron(s: &mut nanoserde::DeRonState, i: &mut core::str::Chars) -> ::core::result::Result<Self,nanoserde::DeRonErr> {{
                 s.paren_open(i)?;
                 let r = Self({});
@@ -404,7 +404,7 @@ pub fn derive_ser_ron_enum(enum_: &Enum) -> TokenStream {
     }
     format!(
         "
-        impl SerRon for {} {{
+        impl nanoserde::SerRon for {} {{
             fn ser_ron(&self, d: usize, s: &mut nanoserde::SerRonState) {{
                 match self {{
                     {}
@@ -448,7 +448,7 @@ pub fn derive_de_ron_enum(enum_: &Enum) -> TokenStream {
                     l!(
                         inner,
                         "{
-                            let r = DeRon::de_ron(s, i)?;
+                            let r = nanoserde::DeRon::de_ron(s, i)?;
                             s.eat_comma_paren(i)?;
                             r
                         }, "
@@ -475,7 +475,7 @@ pub fn derive_de_ron_enum(enum_: &Enum) -> TokenStream {
     }
 
     format! ("
-        impl DeRon for {} {{
+        impl nanoserde::DeRon for {} {{
             fn de_ron(s: &mut nanoserde::DeRonState, i: &mut core::str::Chars) -> ::core::result::Result<Self,nanoserde::DeRonErr> {{
                 // we are expecting an identifier
                 s.ident(i)?;

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -84,8 +84,22 @@ pub fn attrs_serialize_none_as_null(attributes: &[crate::parse::Attribute]) -> b
         .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "serialize_none_as_null")
 }
 
+pub fn attrs_crate(attributes: &[crate::parse::Attribute]) -> Option<&str> {
+    attributes.iter().find_map(|attr| {
+        if attr.tokens.len() == 2 && attr.tokens[0] == "crate" {
+            Some(attr.tokens[1].as_str())
+        } else {
+            None
+        }
+    })
+}
+
 #[cfg(any(feature = "binary", feature = "json"))]
-pub(crate) fn struct_bounds_strings(struct_: &Struct, bound_name: &str) -> (String, String) {
+pub(crate) fn struct_bounds_strings(
+    struct_: &Struct,
+    bound_name: &str,
+    crate_name: &str,
+) -> (String, String) {
     let generics: &Vec<_> = &struct_.generics;
 
     if generics.is_empty() {
@@ -94,7 +108,7 @@ pub(crate) fn struct_bounds_strings(struct_: &Struct, bound_name: &str) -> (Stri
     let mut generic_w_bounds = "<".to_string();
     for generic in generics.iter().filter(|g| g.ident_only() != "Self") {
         generic_w_bounds += generic
-            .full_with_const(&[format!("nanoserde::{}", bound_name).as_str()], true)
+            .full_with_const(&[format!("{}::{}", crate_name, bound_name).as_str()], true)
             .as_str();
         generic_w_bounds += ", ";
     }
@@ -110,7 +124,11 @@ pub(crate) fn struct_bounds_strings(struct_: &Struct, bound_name: &str) -> (Stri
 }
 
 #[cfg(any(feature = "binary", feature = "json"))]
-pub(crate) fn enum_bounds_strings(enum_: &Enum, bound_name: &str) -> (String, String) {
+pub(crate) fn enum_bounds_strings(
+    enum_: &Enum,
+    bound_name: &str,
+    crate_name: &str,
+) -> (String, String) {
     let generics: &Vec<_> = &enum_.generics;
 
     if generics.is_empty() {
@@ -119,7 +137,7 @@ pub(crate) fn enum_bounds_strings(enum_: &Enum, bound_name: &str) -> (String, St
     let mut generic_w_bounds = "<".to_string();
     for generic in generics.iter().filter(|g| g.ident_only() != "Self") {
         generic_w_bounds += generic
-            .full_with_const(&[format!("nanoserde::{}", bound_name).as_str()], true)
+            .full_with_const(&[format!("{}::{}", crate_name, bound_name).as_str()], true)
             .as_str();
         generic_w_bounds += ", ";
     }

--- a/tests/bin.rs
+++ b/tests/bin.rs
@@ -295,3 +295,29 @@ fn array_leak_test() {
 
     assert!(TOGGLED_ON_DROP.load(std::sync::atomic::Ordering::SeqCst))
 }
+
+#[test]
+fn binary_crate() {
+    use nanoserde as renamed;
+    #[derive(renamed::DeBin, renamed::SerBin, PartialEq)]
+    #[nserde(crate = "renamed")]
+    pub struct Test {
+        pub a: i32,
+        pub b: f32,
+        c: Option<String>,
+        d: Option<String>,
+    }
+
+    let test: Test = Test {
+        a: 1,
+        b: 2.,
+        c: Some("asd".to_string()),
+        d: None,
+    };
+
+    let bytes = renamed::SerBin::serialize_bin(&test);
+
+    let test_deserialized = renamed::DeBin::deserialize_bin(&bytes).unwrap();
+
+    assert!(test == test_deserialized);
+}

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1177,3 +1177,28 @@ fn test_deser_oversized_value() {
         )
     );
 }
+
+#[test]
+fn json_crate() {
+    use nanoserde as renamed;
+    #[derive(renamed::DeJson)]
+    #[nserde(crate = "renamed")]
+    pub struct Test {
+        pub a: f32,
+        pub b: f32,
+        c: Option<String>,
+        d: Option<String>,
+    }
+
+    let json = r#"{
+        "a": 1,
+        "b": 2.0,
+        "d": "hello"
+    }"#;
+
+    let test: Test = renamed::DeJson::deserialize_json(json).unwrap();
+    assert_eq!(test.a, 1.);
+    assert_eq!(test.b, 2.);
+    assert_eq!(test.d.unwrap(), "hello");
+    assert_eq!(test.c, None);
+}

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -638,3 +638,29 @@ fn test_deser_oversized_value() {
         )
     );
 }
+
+#[test]
+fn ron_crate() {
+    use nanoserde as renamed;
+
+    #[derive(renamed::DeRon)]
+    #[nserde(crate = "renamed")]
+    pub struct Test {
+        a: i32,
+        b: f32,
+        c: Option<String>,
+        d: Option<String>,
+    }
+
+    let ron = r#"(
+        a: 1,
+        b: 2.0,
+        d: "hello",
+    )"#;
+
+    let test: Test = renamed::DeRon::deserialize_ron(ron).unwrap();
+    assert_eq!(test.a, 1);
+    assert_eq!(test.b, 2.);
+    assert_eq!(test.c, None);
+    assert_eq!(test.d.unwrap(), "hello");
+}


### PR DESCRIPTION
Uses absolute paths in derive-macro generated code to permit not using top-level use statements.

This permits things like:

```rust
#[derive(nanoserde::SerJson, nanoserde::DeJson)]
pub struct Foo {
  val: String,
}
```

Without having a `use nanoserde::{SerJson, DeJson}` at global scope.

This would solve #45 for my use case.