### PR TITLE
bump msrv and crate versions, remove std::error references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "nanoserde"
-version = "0.2.0-beta.2"
+version = "0.2.0"
 authors = ["makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = """Serialization library with zero dependencies.
 Supports Binary, JSON, RON and TOML."""
 edition = "2021"
-rust-version = "1.71.1"
+rust-version = "1.81.0"
 repository = "https://github.com/not-fl3/nanoserde"
 
 [features]
@@ -20,4 +20,4 @@ toml = []
 std = []
 
 [dependencies]
-nanoserde-derive = { path = "derive", version = "=0.2.0-beta.2", optional = true }
+nanoserde-derive = { path = "derive", version = "=0.2.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ No more syn, proc_macro2 or quote in the build tree!
 
 ```
 > cargo tree
-nanoserde v0.1.0 (/../nanoserde)
-└── nanoserde-derive v0.1.0 (/../nanoserde/derive)
+nanoserde v0.2.0 (/../nanoserde)
+└── nanoserde-derive v0.2.0 (/../nanoserde/derive)
 ```
 
 ## Example:

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "nanoserde-derive"
-version = "0.2.0-beta.2"
+version = "0.2.0"
 authors = ["Makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
 edition = "2021"
-rust-version = "1.78.0"
+rust-version = "1.81.0"
 description = "Fork of makepad-tinyserde derive without any external dependencies"
 license = "MIT"
 

--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -1,10 +1,5 @@
 use core::convert::TryInto;
-
-// remove this after 1.81 is live
-#[cfg(not(feature = "std"))]
 use core::error::Error;
-#[cfg(feature = "std")]
-use std::error::Error;
 
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -1,10 +1,5 @@
-use core::str::Chars;
-
-// remove this after 1.81 is msrv
-#[cfg(not(feature = "std"))]
 use core::error::Error;
-#[cfg(feature = "std")]
-use std::error::Error;
+use core::str::Chars;
 
 use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet, LinkedList};

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -1,10 +1,5 @@
-use core::str::Chars;
-
-// remove this after 1.81 is live
-#[cfg(not(feature = "std"))]
 use core::error::Error;
-#[cfg(feature = "std")]
-use std::error::Error;
+use core::str::Chars;
 
 use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet, LinkedList};

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -1,10 +1,5 @@
-use core::str::Chars;
-
-// remove this after 1.81 is live
-#[cfg(not(feature = "std"))]
 use core::error::Error;
-#[cfg(feature = "std")]
-use std::error::Error;
+use core::str::Chars;
 
 use alloc::format;
 use alloc::string::{String, ToString};


### PR DESCRIPTION
I think we have just about all the changes that are reasonable to wait for for v0.2. All the breaking changes are pretty small, and the majority of users will likely only need to adjust MSRV. This PR bumps the MSRV to 1.81, the crate versions to 0.2, and removes the import of `std::error::error`

Breaking changes:
- A non-exhasutive `ErrReason` added to Error structs to improve forward compatibility
    - Breaks anyone who was destructuring/manually creating the `De{format}Err` structs
    - Can be fixed by non-exhaustively matching on error reason
- `binary`/`json`/`ron`/`toml` formats split into feature flags, with all enabled by default
    - Breaks anyone who was using `default-features = false` before, but we didn't have any features so should be rare
- `no_std` feature removed, added `std` feature which gates the couple remaining items (mostly `HashMap/HashSet`)
    - Breaks anyone who used the old `no_std` feature 
    - Can be fixed by removing the `no_std` feature, and switching to `default-features = false`
- Bump MSRV to 1.81 (for `core::error::Error`)
    - Breaks anyone who is on a rust version <1.81
- Hardcode the `nanoserde` crate name (with override)
    - Breaks anyone who renamed the nanoserde crate and used the derive macros
    - Can be fixed using default name or the new `nserde(crate="renamed")` attribute

Other changes since last non-beta release:
- Support for comments in JSON
- Support for `nserde(default)` on non-`Option` types and 
- Bug fixes to float serialization, proxy attrs, along with `toml` and explicitly numbered enum parsing
- Removed `no_std` `hashbrown` dependency