### PR TITLE
add reason enum to use instead of string value for error messages

### DIFF
--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "json")]
-use nanoserde::{DeJson, SerJson};
+use nanoserde::{DeJson, DeJsonErrReason, SerJson};
 
 use std::{
     collections::{BTreeMap, BTreeSet, LinkedList},
@@ -1166,16 +1166,14 @@ fn test_deser_oversized_value() {
         <EnumConstant as DeJson>::deserialize_json(&max_json).unwrap(),
         EnumConstant { value: i32::MAX }
     );
-    assert_eq!(
+
+    assert!(matches!(
         <EnumConstant as DeJson>::deserialize_json(&wrap_json)
             .unwrap_err()
             .msg,
-        format!(
-            "Value out of range {}>{} ",
-            (i32::MAX as i64 + 1).to_string(),
-            i32::MAX.to_string()
-        )
-    );
+        DeJsonErrReason::OutOfRange(v)
+            if v == format!("{}>{}", (i32::MAX as i64 + 1), i32::MAX),
+    ));
 }
 
 #[test]

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "ron")]
-use nanoserde::{DeRon, SerRon};
+use nanoserde::{DeRon, DeRonErrReason, SerRon};
 
 use std::{
     collections::{BTreeMap, BTreeSet, LinkedList},
@@ -627,16 +627,14 @@ fn test_deser_oversized_value() {
         <EnumConstant as DeRon>::deserialize_ron(&max_ron).unwrap(),
         EnumConstant { value: i32::MAX }
     );
-    assert_eq!(
+
+    assert!(matches!(
         <EnumConstant as DeRon>::deserialize_ron(&wrap_ron)
             .unwrap_err()
             .msg,
-        format!(
-            "Value out of range {}>{} ",
-            (i32::MAX as i64 + 1).to_string(),
-            i32::MAX.to_string()
-        )
-    );
+        DeRonErrReason::OutOfRange(v)
+            if v == format!("{}>{}", (i32::MAX as i64 + 1), i32::MAX),
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Changes the error type so that new variants may be added in future without breaking changes