### PR TITLE
Cleanup and optimize derive macro code generation

### DIFF
--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -1391,7 +1391,7 @@ fn next_generic<T: Iterator<Item = TokenTree> + Clone>(
 fn get_all_bounds<T: Iterator<Item = TokenTree> + Clone>(source: &mut Peekable<T>) -> Vec<Generic> {
     let mut ret = Vec::new();
     let mut already = BTreeSet::new();
-    if source.peek().map_or(false, |x| x.to_string() == "<") {
+    if source.peek().is_some_and(|x| x.to_string() == "<") {
         source.next();
     } else {
         return ret;

--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -151,13 +151,14 @@ pub fn derive_de_json_named(
         let default_val = if let Some(v) = field_attr_default {
             if let Some(mut val) = v {
                 if field.ty.base() == "String"
-                    || field.ty.wraps.as_ref().map_or(false, |wrapped| {
-                        wrapped.iter().any(|ty| ty.base() == "String")
-                    })
+                    || field
+                        .ty
+                        .wraps
+                        .as_ref()
+                        .is_some_and(|wrapped| wrapped.iter().any(|ty| ty.base() == "String"))
                 {
                     val = format!("\"{}\".to_string()", val)
-                }
-                if field.ty.base() == "Option" {
+                } else if field.ty.base() == "Option" {
                     val = format!("Some({})", val);
                 }
                 Some(val)

--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -158,7 +158,8 @@ pub fn derive_de_json_named(
                         .is_some_and(|wrapped| wrapped.iter().any(|ty| ty.base() == "String"))
                 {
                     val = format!("\"{}\".to_string()", val)
-                } else if field.ty.base() == "Option" {
+                }
+                if field.ty.base() == "Option" {
                     val = format!("Some({})", val);
                 }
                 Some(val)

--- a/derive/src/serde_ron.rs
+++ b/derive/src/serde_ron.rs
@@ -145,8 +145,7 @@ pub fn derive_de_ron_named(
             if let Some(mut val) = v {
                 if field.ty.base() == "String" {
                     val = format!("\"{}\".to_string()", val)
-                }
-                if field.ty.base() == "Option" {
+                } else if field.ty.base() == "Option" {
                     val = format!("Some({})", val);
                 }
                 Some(val)


### PR DESCRIPTION
I've been getting some clippy warnings when using `DeJson`, so I've cleaned up some unnecessary destructuring and replaced it with more fitting functions. I also found some `if` statements that were mutually exclusive and turned them into `if/else` statements.