### PR TITLE
Add the Carriage Return to ident_term_chars

### DIFF
--- a/src/toml.rs
+++ b/src/toml.rs
@@ -37,7 +37,7 @@ macro_rules! ident_chars {
 /// Pattern matching a character that can terminate a valid ident.
 macro_rules! ident_term_chars {
     () => {
-        ' ' | '\t' | '\n' | '\0' | '=' | ']'
+        ' ' | '\t' | '\r' | '\n' | '\0' | '=' | ']'
     };
 }
 

--- a/tests/toml.rs
+++ b/tests/toml.rs
@@ -113,3 +113,12 @@ fn toml_key_chars() {
         ])
     );
 }
+
+#[test]
+fn carriage_return() {
+    let toml_str = "foo = 1\r\nbar = false\r\n";
+    let toml = TomlParser::parse(toml_str).unwrap();
+
+    assert_eq!(toml["foo"].num(), 1.0);
+    assert_eq!(toml["bar"].boolean(), false);
+}


### PR DESCRIPTION
When parsing for identifiers it included the carriage return, throwing a "`Cannot parse toml tokenizer`" toml error instead of ignoring it, most noticeable with boolean values

E.g.
````rust
[src\main.rs:55:5] TomlParser::parse("public = false\r\n") = Err(
    Toml error: Cannot parse toml tokenizer , line:1 col:1,
)
````

This fixes that, while also adding a test for carriage returns
