### PR TITLE
Add support for generic parameters on enums

### DIFF
--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -203,12 +203,10 @@ impl Generic {
         }
     }
 
-    #[cfg(any(feature = "binary", feature = "json"))]
     pub fn ident_only(&self) -> String {
         format!("{}{}", self.lifetime_prefix(), self.full())
     }
 
-    #[cfg(any(feature = "binary", feature = "json"))]
     pub fn full_with_const(&self, extra_bounds: &[&str], bounds: bool) -> String {
         let bounds = match (bounds, &self) {
             (true, Generic::Lifetime { .. }) => self.get_bounds().join(" + "),

--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -298,6 +298,7 @@ pub fn derive_de_json_struct(struct_: &Struct, crate_name: &str) -> TokenStream 
 
 pub fn derive_ser_json_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
     let mut r = String::new();
+    let (generic_w_bounds, generic_no_bounds) = enum_bounds_strings(enum_, "SerJson", crate_name);
 
     for variant in enum_.variants.iter() {
         let field_name = variant.field_name.clone().unwrap();
@@ -423,14 +424,14 @@ pub fn derive_ser_json_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
 
     format!(
         "
-        impl {}::SerJson for {} {{
+        impl{} {}::SerJson for {}{} {{
             fn ser_json(&self, d: usize, s: &mut {}::SerJsonState) {{
                 match self {{
                     {}
                 }}
             }}
         }}",
-        crate_name, enum_.name, crate_name, r
+        generic_w_bounds, crate_name, enum_.name, generic_no_bounds, crate_name, r
     )
     .parse()
     .unwrap()

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -1,12 +1,8 @@
 #![cfg(any(feature = "json", feature = "ron", feature = "binary"))]
 
-#[cfg(any(feature = "json", feature = "binary"))]
-use alloc::{format, string::ToString, vec::Vec};
-
-use alloc::string::String;
-
-#[cfg(any(feature = "binary", feature = "json"))]
 use crate::parse::{Enum, Struct};
+use alloc::string::String;
+use alloc::{format, string::ToString, vec::Vec};
 
 macro_rules! l {
     ($target:ident, $line:expr) => {

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -94,7 +94,6 @@ pub fn attrs_crate(attributes: &[crate::parse::Attribute]) -> Option<&str> {
     })
 }
 
-#[cfg(any(feature = "binary", feature = "json"))]
 pub(crate) fn struct_bounds_strings(
     struct_: &Struct,
     bound_name: &str,
@@ -123,7 +122,6 @@ pub(crate) fn struct_bounds_strings(
     (generic_w_bounds, generic_no_bounds)
 }
 
-#[cfg(any(feature = "binary", feature = "json"))]
 pub(crate) fn enum_bounds_strings(
     enum_: &Enum,
     bound_name: &str,

--- a/tests/bin.rs
+++ b/tests/bin.rs
@@ -324,3 +324,40 @@ fn binary_crate() {
 
     assert!(test == test_deserialized);
 }
+
+#[test]
+fn generic_enum() {
+    #[derive(DeBin, SerBin, PartialEq, Debug)]
+    pub enum Foo<T, U>
+    where
+        T: Copy,
+        U: Clone,
+    {
+        A,
+        B(T, String),
+        C { a: U, b: String },
+    }
+
+    #[derive(DeBin, SerBin, PartialEq, Debug)]
+    pub struct Bar<T, U>
+    where
+        T: Copy,
+        U: Clone,
+    {
+        foo1: Foo<T, U>,
+        foo2: Foo<T, U>,
+        foo3: Foo<T, U>,
+    }
+
+    let test = Bar {
+        foo1: Foo::A,
+        foo2: Foo::B(1, "asd".to_string()),
+        foo3: Foo::C {
+            a: 2,
+            b: "qwe".to_string(),
+        },
+    };
+    let bytes = SerBin::serialize_bin(&test);
+    let test_deserialized = DeBin::deserialize_bin(&bytes).unwrap();
+    assert!(test == test_deserialized);
+}

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1204,17 +1204,25 @@ fn json_crate() {
 #[test]
 fn generic_enum() {
     #[derive(DeJson, SerJson, PartialEq, Debug)]
-    pub enum Foo<T> {
+    pub enum Foo<T, U>
+    where
+        T: Copy,
+        U: Clone,
+    {
         A,
         B(T, String),
-        C { a: T, b: String },
+        C { a: U, b: String },
     }
 
     #[derive(DeJson, SerJson, PartialEq, Debug)]
-    pub struct Bar<T> {
-        foo1: Foo<T>,
-        foo2: Foo<T>,
-        foo3: Foo<T>,
+    pub struct Bar<T, U>
+    where
+        T: Copy,
+        U: Clone,
+    {
+        foo1: Foo<T, U>,
+        foo2: Foo<T, U>,
+        foo3: Foo<T, U>,
     }
 
     let json = r#"
@@ -1225,7 +1233,7 @@ fn generic_enum() {
        }
     "#;
 
-    let test: Bar<i32> = DeJson::deserialize_json(json).unwrap();
+    let test: Bar<i32, u64> = DeJson::deserialize_json(json).unwrap();
     assert_eq!(test.foo1, Foo::A);
     assert_eq!(test.foo2, Foo::B(1, "asd".to_string()));
     assert_eq!(

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -713,17 +713,25 @@ fn no_whitespace_when_serialized() {
 #[test]
 fn generic_enum() {
     #[derive(DeRon, PartialEq, Debug)]
-    pub enum Foo<T> {
+    pub enum Foo<T, U>
+    where
+        T: Copy,
+        U: Clone,
+    {
         A,
         B(T, String),
-        C { a: T, b: String },
+        C { a: U, b: String },
     }
 
     #[derive(DeRon, PartialEq, Debug)]
-    pub struct Bar<T> {
-        foo1: Foo<T>,
-        foo2: Foo<T>,
-        foo3: Foo<T>,
+    pub struct Bar<T, U>
+    where
+        T: Copy,
+        U: Clone,
+    {
+        foo1: Foo<T, U>,
+        foo2: Foo<T, U>,
+        foo3: Foo<T, U>,
     }
 
     let ron = r#"
@@ -734,7 +742,7 @@ fn generic_enum() {
        )
     "#;
 
-    let test: Bar<i32> = DeRon::deserialize_ron(ron).unwrap();
+    let test: Bar<i32, u64> = DeRon::deserialize_ron(ron).unwrap();
 
     assert_eq!(test.foo1, Foo::A);
     assert_eq!(test.foo2, Foo::B(1, "asd".to_string()));

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -709,3 +709,40 @@ fn no_whitespace_when_serialized() {
         assert!(no_whitespace);
     }
 }
+
+#[test]
+fn generic_enum() {
+    #[derive(DeRon, PartialEq, Debug)]
+    pub enum Foo<T> {
+        A,
+        B(T, String),
+        C { a: T, b: String },
+    }
+
+    #[derive(DeRon, PartialEq, Debug)]
+    pub struct Bar<T> {
+        foo1: Foo<T>,
+        foo2: Foo<T>,
+        foo3: Foo<T>,
+    }
+
+    let ron = r#"
+       (
+          foo1: A,
+          foo2: B(1, "asd"),
+          foo3: C(a: 2, b: "qwe"),
+       )
+    "#;
+
+    let test: Bar<i32> = DeRon::deserialize_ron(ron).unwrap();
+
+    assert_eq!(test.foo1, Foo::A);
+    assert_eq!(test.foo2, Foo::B(1, "asd".to_string()));
+    assert_eq!(
+        test.foo3,
+        Foo::C {
+            a: 2,
+            b: "qwe".to_string()
+        }
+    );
+}


### PR DESCRIPTION
Adds the ability to specify a generic parameter on enums. In some cases for JSON and RON formats, the generic parameter was not propagated properly.