### PR TITLE
Impl `SerJson` for `HashMap<&str, T>` and other types

### DIFF
--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -1379,3 +1379,12 @@ impl DeJson for std::time::SystemTime {
         }
     }
 }
+
+impl<T> SerJson for &T
+where
+    T: SerJson + ?Sized,
+{
+    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+        (**self).ser_json(d, s);
+    }
+}

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -603,6 +603,8 @@ fn serialize_hashmap_with_str_keys() {
     assert_eq!(hm["bar"], 2);
 }
 
+#[cfg(feature = "std")]
+#[test]
 fn serialize_hashmap_with_custom_hasher() {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::BuildHasherDefault;

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -588,6 +588,21 @@ fn hashmaps() {
     assert_eq!(foo.map["qwe"], 2);
 }
 
+#[cfg(feature = "std")]
+#[test]
+fn serialize_hashmap_with_str_keys() {
+    let mut hm: HashMap<&str, i32> = HashMap::new();
+    hm.insert("foo", 1);
+    hm.insert("bar", 2);
+
+    let json = SerJson::serialize_json(&hm);
+
+    let hm: HashMap<String, i32> = DeJson::deserialize_json(&json).unwrap();
+    assert_eq!(hm.len(), 2);
+    assert_eq!(hm["foo"], 1);
+    assert_eq!(hm["bar"], 2);
+}
+
 #[test]
 fn exponents() {
     #[derive(DeJson)]


### PR DESCRIPTION
I was integrating `nanoserde` in a project of mine but ran into difficulty when trying to serialize a `HashMap<&'static str, MyStructThatImplsSerJson>` to JSON.  This was due to the fact that `str` implements `SerJson` but not `&str`.

This fix makes it so that things work as expected for that case and many others too (`Vec<&str>`, `&[&usize]`, etc.)`

## Changes

 * Add an auto-impl for `SerJson` for `&T: SerJson`.  This allows types like `HashMap<&'static str, &'static str>` and many others to serialize to JSON while they previously couldn't
 * Add a test to verify that `HashMap<&str, T>` can actually be serialized and produces correct results