### PR TITLE
Impl `SerJson` + `DeJson` for `HashMap`s with custom hashers

### DIFF
--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -1203,7 +1203,7 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<K, V> SerJson for std::collections::HashMap<K, V>
+impl<K, V, S> SerJson for std::collections::HashMap<K, V, S>
 where
     K: SerJson,
     V: SerJson,
@@ -1226,13 +1226,14 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<K, V> DeJson for std::collections::HashMap<K, V>
+impl<K, V, S> DeJson for std::collections::HashMap<K, V, S>
 where
     K: DeJson + Eq + core::hash::Hash,
     V: DeJson,
+    S: core::hash::BuildHasher + Default,
 {
     fn de_json(s: &mut DeJsonState, i: &mut Chars) -> Result<Self, DeJsonErr> {
-        let mut h = std::collections::HashMap::new();
+        let mut h = std::collections::HashMap::with_hasher(S::default());
         s.curly_open(i)?;
         while s.tok != DeJsonTok::CurlyClose {
             let k = DeJson::de_json(s, i)?;

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -588,6 +588,30 @@ fn hashmaps() {
     assert_eq!(foo.map["qwe"], 2);
 }
 
+#[cfg(feature = "std")]
+#[test]
+fn serialize_hashmap_with_custom_hasher() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::BuildHasherDefault;
+
+    #[derive(DeJson, SerJson, Debug)]
+    struct CustomHasherMap {
+        map: HashMap<String, usize, BuildHasherDefault<DefaultHasher>>,
+    }
+
+    let mut map = CustomHasherMap {
+        map: HashMap::default(),
+    };
+    map.map.insert("key1".to_string(), 1);
+    map.map.insert("key2".to_string(), 2);
+
+    let json = SerJson::serialize_json(&map);
+    let deserialized: CustomHasherMap = DeJson::deserialize_json(&json).unwrap();
+
+    assert_eq!(deserialized.map["key1"], 1);
+    assert_eq!(deserialized.map["key2"], 2);
+}
+
 #[test]
 fn exponents() {
     #[derive(DeJson)]


### PR DESCRIPTION
 * This makes crates like `fxhash` usable with `nanoserde`
 * Add test verifying that hashmaps with custom hashers can be serialized + deserialized to/from JSON