### PR TITLE
Fix unit struct serializing to invalid Json

### DIFF
--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -560,8 +560,8 @@ pub fn derive_ser_json_struct_unnamed(struct_: &Struct, crate_name: &str) -> Tok
 
     // encode empty struct as {}
     if struct_.fields.is_empty() {
-        l!(body, "s.out.push('}');");
         l!(body, "s.out.push('{');");
+        l!(body, "s.out.push('}');");
     }
     // if its a newtype struct and it should be transparent - skip any curles
     // and skip "container"


### PR DESCRIPTION
Unit struct serialized to `}{` instead of `{}`

```rs
#[derive(SerJson, DeJson, PartialEq, Debug)]
struct A;

#[test]
fn test_nanoserde() {
    let a = A;
    let json = a.serialize_json();
    println!("{}", json);
    let a1: A = DeJson::deserialize_json(&json).unwrap();
    assert_eq!(a, a1);
}
```

lead to this error -
```
running 1 test
test test_nanoserde ... FAILED

failures:

---- test_nanoserde stdout ----
}{

thread 'test_nanoserde' panicked at src/lib.rs:11:49:
called `Result::unwrap()` on an `Err` value: Json Deserialize error: Unexpected token CurlyClose expected { , line:1 col:3
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_nanoserde

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```