### PR TITLE
Add DeBinErrReason::UnknownDiscriminant variant 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanoserde"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = """Serialization library with zero dependencies.
@@ -20,4 +20,4 @@ toml = []
 std = []
 
 [dependencies]
-nanoserde-derive = { path = "derive", version = "=0.2.1", optional = true }
+nanoserde-derive = { path = "derive", version = "=0.2.2", optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanoserde-derive"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>"]
 edition = "2021"
 rust-version = "1.81.0"

--- a/derive/src/serde_bin.rs
+++ b/derive/src/serde_bin.rs
@@ -372,7 +372,7 @@ pub fn derive_de_bin_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
                 let id: u16 = {}::DeBin::de_bin(o,d)?;
                 Ok(match id {{
                     {}
-                    _ => return ::core::result::Result::Err({}::DeBinErr::new(*o, 0, d.len()))
+                    unknown => return ::core::result::Result::Err({}::DeBinErr{{o: 0, msg: {}::DeBinErrReason::UnknownDiscriminant(unknown as isize)}})
                 }})
             }}
         }}",
@@ -383,6 +383,7 @@ pub fn derive_de_bin_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
         crate_name,
         crate_name,
         r,
+        crate_name,
         crate_name
     )
     .parse()

--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -64,6 +64,7 @@ pub enum DeBinErrReason {
         actual_length: usize,
     },
     Range(String),
+    UnknownDiscriminant(isize),
 }
 
 /// The error message when failing to deserialize.
@@ -99,6 +100,11 @@ impl core::fmt::Debug for DeBinErr {
                 self.o, l, s
             ),
             DeBinErrReason::Range(ref s) => write!(f, "Bin deserialize error at:{} {}", self.o, s),
+            DeBinErrReason::UnknownDiscriminant(variant) => write!(
+                f,
+                "Bin deserialize error at {}: Unknown variant {}",
+                self.o, variant
+            ),
         }
     }
 }


### PR DESCRIPTION
instead of using ::Length err reason for unknown discriminant on enum deserialization, add a dedicated error for it. 