### PR TITLE
Remove unused indent functions in ser_json and ser_ron and remove `d: usize` depth parameter

### DIFF
--- a/derive/src/serde_json.rs
+++ b/derive/src/serde_json.rs
@@ -14,9 +14,9 @@ use proc_macro::TokenStream;
 pub fn derive_ser_json_proxy(proxy_type: &str, type_: &str, crate_name: &str) -> TokenStream {
     format!(
         "impl {}::SerJson for {} {{
-            fn ser_json(&self, d: usize, s: &mut {}::SerJsonState) {{
+            fn ser_json(&self, s: &mut {}::SerJsonState) {{
                 let proxy: {} = self.into();
-                proxy.ser_json(d, s);
+                proxy.ser_json(s);
             }}
         }}",
         crate_name, type_, crate_name, proxy_type
@@ -68,7 +68,7 @@ pub fn derive_ser_json_struct(struct_: &Struct, crate_name: &str) -> TokenStream
                                                  s.conl();
                                              }};
                                              first_field_was_serialized = true;
-                                             s.field(d+1, \"{}\");",
+                                             s.field(\"{}\");",
                     json_fieldname
                 );
                 l!(
@@ -76,14 +76,14 @@ pub fn derive_ser_json_struct(struct_: &Struct, crate_name: &str) -> TokenStream
                     "{}
                     if let Some(t) = &{} {{
                         {}
-                        t.ser_json(d+1, s);
+                        t.ser_json(s);
                     }} {}",
                     if null_on_none { field_header } else { "" },
                     proxied_field,
                     if null_on_none { "" } else { field_header },
                     if null_on_none {
                         "else {{
-                            Option::<i32>::ser_json(&None, d+1, s);
+                            Option::<i32>::ser_json(&None, s);
                         }}"
                     } else {
                         ""
@@ -96,8 +96,8 @@ pub fn derive_ser_json_struct(struct_: &Struct, crate_name: &str) -> TokenStream
                         s.conl();
                     }};
                     first_field_was_serialized = true;
-                    s.field(d+1,\"{}\");
-                    {}.ser_json(d+1, s);",
+                    s.field(\"{}\");
+                    {}.ser_json(s);",
                     json_fieldname,
                     proxied_field
                 );
@@ -108,10 +108,10 @@ pub fn derive_ser_json_struct(struct_: &Struct, crate_name: &str) -> TokenStream
     format!(
         "
         impl{} {}::SerJson for {}{} {{
-            fn ser_json(&self, d: usize, s: &mut {}::SerJsonState) {{
+            fn ser_json(&self, s: &mut {}::SerJsonState) {{
                 s.st_pre();
                 {}
-                s.st_post(d);
+                s.st_post();
             }}
         }}
     ",
@@ -334,7 +334,7 @@ pub fn derive_ser_json_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
                             if field.ty.base() == "Option" {
                                 l!(
                                     items,
-                                    "if {}.is_some(){{s.field(d+1, \"{}\");{}.ser_json(d+1, s);}}",
+                                    "if {}.is_some(){{s.field(\"{}\");{}.ser_json(s);}}",
                                     name,
                                     name,
                                     proxied_field
@@ -342,23 +342,23 @@ pub fn derive_ser_json_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
                             } else {
                                 l!(
                                     items,
-                                    "s.field(d+1, \"{}\");{}.ser_json(d+1, s);",
+                                    "s.field(\"{}\");{}.ser_json(s);",
                                     name,
                                     proxied_field
                                 )
                             }
                         } else if field.ty.base() == "Option" {
                             l!(
-                                    items,
-                                    "if {}.is_some(){{s.field(d+1, \"{}\");{}.ser_json(d+1, s);s.conl();}}",
-                                    name,
-                                    name,
-                                    proxied_field
-                                );
+                                items,
+                                "if {}.is_some(){{s.field(\"{}\");{}.ser_json(s);s.conl();}}",
+                                name,
+                                name,
+                                proxied_field
+                            );
                         } else {
                             l!(
                                 items,
-                                "s.field(d+1, \"{}\");{}.ser_json(d+1, s);s.conl();",
+                                "s.field(\"{}\");{}.ser_json(s);s.conl();",
                                 name,
                                 proxied_field
                             );
@@ -374,7 +374,7 @@ pub fn derive_ser_json_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
                                 s.out.push(':');
                                 s.st_pre();
                                 {}
-                                s.st_post(d);
+                                s.st_post();
                                 s.out.push('}}');
                             }}",
                     &field_name,
@@ -394,9 +394,9 @@ pub fn derive_ser_json_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
                     let field_name = format!("f{}", index);
                     names.push(field_name.clone());
                     if index != last {
-                        l!(inner, "{}.ser_json(d, s); s.out.push(',');", field_name);
+                        l!(inner, "{}.ser_json(s); s.out.push(',');", field_name);
                     } else {
-                        l!(inner, "{}.ser_json(d, s);", field_name);
+                        l!(inner, "{}.ser_json(s);", field_name);
                     }
                 }
                 if contents.len() == 1 {
@@ -442,7 +442,7 @@ pub fn derive_ser_json_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
     format!(
         "
         impl{} {}::SerJson for {}{} {{
-            fn ser_json(&self, d: usize, s: &mut {}::SerJsonState) {{
+            fn ser_json(&self, s: &mut {}::SerJsonState) {{
                 match self {{
                     {}
                 }}
@@ -494,8 +494,6 @@ pub fn derive_de_json_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
                 ident: Category::Tuple { contents },
                 ..
             } => {
-                
-
                 if contents.len() == 1 {
                     l!(
                         r_rest,
@@ -595,14 +593,14 @@ pub fn derive_ser_json_struct_unnamed(struct_: &Struct, crate_name: &str) -> Tok
     // if its a newtype struct and it should be transparent - skip any curles
     // and skip "container"
     else if transparent && struct_.fields.len() == 1 {
-        l!(body, "self.{}.ser_json(d, s);", 0);
+        l!(body, "self.{}.ser_json(s);", 0);
     }
     // if more than one field - encode as array []
     else {
         l!(body, "s.out.push('[');");
         let last = struct_.fields.len() - 1;
         for (n, _) in struct_.fields.iter().enumerate() {
-            l!(body, "self.{}.ser_json(d, s);", n);
+            l!(body, "self.{}.ser_json(s);", n);
             if n != last {
                 l!(body, "s.out.push_str(\", \");");
             }
@@ -613,7 +611,7 @@ pub fn derive_ser_json_struct_unnamed(struct_: &Struct, crate_name: &str) -> Tok
     format!(
         "
         impl{} {}::SerJson for {}{} {{
-            fn ser_json(&self, d: usize, s: &mut {}::SerJsonState) {{
+            fn ser_json(&self, s: &mut {}::SerJsonState) {{
                 {}
             }}
         }}",

--- a/derive/src/serde_ron.rs
+++ b/derive/src/serde_ron.rs
@@ -14,9 +14,9 @@ use crate::shared::{self, attrs_skip};
 pub fn derive_ser_ron_proxy(proxy_type: &str, type_: &str, crate_name: &str) -> TokenStream {
     format!(
         "impl {}::SerRon for {} {{
-            fn ser_ron(&self, d: usize, s: &mut {}::SerRonState) {{
+            fn ser_ron(&self, s: &mut {}::SerRonState) {{
                 let proxy: {} = self.into();
-                proxy.ser_ron(d, s);
+                proxy.ser_ron(s);
             }}
         }}",
         crate_name, type_, crate_name, proxy_type
@@ -56,8 +56,8 @@ pub fn derive_ser_ron_struct(struct_: &Struct, crate_name: &str) -> TokenStream 
             l!(
                 s,
                 "if let Some(t) = &self.{} {{
-                    s.field(d+1, \"{}\");
-                    t.ser_ron(d+1, s);
+                    s.field(\"{}\");
+                    t.ser_ron(s);
                     s.conl();
                 }};",
                 struct_fieldname,
@@ -66,8 +66,8 @@ pub fn derive_ser_ron_struct(struct_: &Struct, crate_name: &str) -> TokenStream 
         } else {
             l!(
                 s,
-                "s.field(d+1,\"{}\");
-                self.{}.ser_ron(d+1, s);
+                "s.field(\"{}\");
+                self.{}.ser_ron(s);
                 s.conl();",
                 ron_fieldname,
                 struct_fieldname
@@ -78,10 +78,10 @@ pub fn derive_ser_ron_struct(struct_: &Struct, crate_name: &str) -> TokenStream 
     format!(
         "
         impl{} {}::SerRon for {}{} {{
-            fn ser_ron(&self, d: usize, s: &mut {}::SerRonState) {{
+            fn ser_ron(&self, s: &mut {}::SerRonState) {{
                 s.st_pre();
                 {}
-                s.st_post(d);
+                s.st_post();
             }}
         }}
     ",
@@ -111,7 +111,7 @@ pub fn derive_ser_ron_struct_unnamed(struct_: &Struct, crate_name: &str) -> Toke
         .enumerate()
         .filter(|(_, f)| !attrs_skip(&f.attributes))
     {
-        l!(body, "self.{}.ser_ron(d, s);", n);
+        l!(body, "self.{}.ser_ron(s);", n);
         if n != last {
             l!(body, "s.out.push_str(\", \");");
         }
@@ -119,7 +119,7 @@ pub fn derive_ser_ron_struct_unnamed(struct_: &Struct, crate_name: &str) -> Toke
     format!(
         "
         impl{} {}::SerRon for {}{} {{
-            fn ser_ron(&self, d: usize, s: &mut {}::SerRonState) {{
+            fn ser_ron(&self, s: &mut {}::SerRonState) {{
                 s.out.push('(');
                 {}
                 s.out.push(')');
@@ -356,8 +356,8 @@ pub fn derive_ser_ron_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
                         l!(
                             inner,
                             "if {}.is_some() {{
-                                s.field(d+1, \"{}\");
-                                {}.ser_ron(d+1, s);
+                                s.field(\"{}\");
+                                {}.ser_ron(s);
                                 s.conl();
                             }}",
                             name.as_str(),
@@ -367,8 +367,8 @@ pub fn derive_ser_ron_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
                     } else {
                         l!(
                             inner,
-                            "s.field(d+1, \"{}\");
-                            {}.ser_ron(d+1, s);
+                            "s.field(\"{}\");
+                            {}.ser_ron(s);
                             s.conl();",
                             name,
                             name
@@ -381,7 +381,7 @@ pub fn derive_ser_ron_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
                         s.out.push_str(\"{}\");
                         s.st_pre();
                         {}
-                        s.st_post(d);
+                        s.st_post();
                     }}",
                     ident,
                     names.join(","),
@@ -398,7 +398,7 @@ pub fn derive_ser_ron_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
                 let last = contents.len() - 1;
                 for (index, _) in &mut contents.iter().enumerate() {
                     let name = format!("f{}", index);
-                    l!(inner, "{}.ser_ron(d, s);", name);
+                    l!(inner, "{}.ser_ron(s);", name);
                     if index != last {
                         l!(inner, "s.out.push_str(\",\");")
                     }
@@ -426,7 +426,7 @@ pub fn derive_ser_ron_enum(enum_: &Enum, crate_name: &str) -> TokenStream {
     format!(
         "
         impl{} {}::SerRon for {}{} {{
-            fn ser_ron(&self, d: usize, s: &mut {}::SerRonState) {{
+            fn ser_ron(&self, s: &mut {}::SerRonState) {{
                 match self {{
                     {}
                 }}

--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -18,14 +18,7 @@ impl SerJsonState {
         Self { out }
     }
 
-    pub fn indent(&mut self, _d: usize) {
-        //for _ in 0..d {
-        //    self.out.push_str("    ");
-        //}
-    }
-
-    pub fn field(&mut self, d: usize, field: &str) {
-        self.indent(d);
+    pub fn field(&mut self, field: &str) {
         self.out.push('"');
         self.out.push_str(field);
         self.out.push('"');
@@ -46,8 +39,7 @@ impl SerJsonState {
         self.out.push('{');
     }
 
-    pub fn st_post(&mut self, d: usize) {
-        self.indent(d);
+    pub fn st_post(&mut self) {
         self.out.push('}');
     }
 }
@@ -59,7 +51,7 @@ pub trait SerJson {
     /// This is a convenient wrapper around `ser_json`.
     fn serialize_json(&self) -> String {
         let mut s = SerJsonState { out: String::new() };
-        self.ser_json(0, &mut s);
+        self.ser_json(&mut s);
         s.out
     }
 
@@ -68,10 +60,10 @@ pub trait SerJson {
     /// ```rust
     /// # use nanoserde::*;
     /// let mut s = SerJsonState::new(String::new());
-    /// 42u32.ser_json(0, &mut s);
+    /// 42u32.ser_json(&mut s);
     /// assert_eq!(s.out, "42");
     /// ```
-    fn ser_json(&self, d: usize, s: &mut SerJsonState);
+    fn ser_json(&self, s: &mut SerJsonState);
 }
 
 /// A trait for objects that can be deserialized from JSON.
@@ -707,7 +699,7 @@ impl DeJsonState {
 macro_rules! impl_ser_de_json_unsigned {
     ( $ ty: ident, $ max: expr) => {
         impl SerJson for $ty {
-            fn ser_json(&self, _d: usize, s: &mut SerJsonState) {
+            fn ser_json(&self, s: &mut SerJsonState) {
                 _ = write!(s.out, "{self}");
             }
         }
@@ -725,7 +717,7 @@ macro_rules! impl_ser_de_json_unsigned {
 macro_rules! impl_ser_de_json_signed {
     ( $ ty: ident, $ min: expr, $ max: expr) => {
         impl SerJson for $ty {
-            fn ser_json(&self, _d: usize, s: &mut SerJsonState) {
+            fn ser_json(&self, s: &mut SerJsonState) {
                 _ = write!(s.out, "{self}");
             }
         }
@@ -744,7 +736,7 @@ macro_rules! impl_ser_de_json_signed {
 macro_rules! impl_ser_de_json_float {
     ( $ ty: ident) => {
         impl SerJson for $ty {
-            fn ser_json(&self, _d: usize, s: &mut SerJsonState) {
+            fn ser_json(&self, s: &mut SerJsonState) {
                 _ = write!(s.out, "{self:?}");
             }
         }
@@ -776,9 +768,9 @@ impl<T> SerJson for Option<T>
 where
     T: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         if let Some(v) = self {
-            v.ser_json(d, s);
+            v.ser_json(s);
         } else {
             s.out.push_str("null");
         }
@@ -799,7 +791,7 @@ where
 }
 
 impl SerJson for () {
-    fn ser_json(&self, _d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push_str("null")
     }
 }
@@ -816,7 +808,7 @@ impl DeJson for () {
 }
 
 impl SerJson for bool {
-    fn ser_json(&self, _d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         if *self {
             s.out.push_str("true")
         } else {
@@ -836,7 +828,7 @@ impl DeJson for bool {
 macro_rules! impl_ser_json_string {
     ($ty: ident) => {
         impl SerJson for $ty {
-            fn ser_json(&self, _d: usize, s: &mut SerJsonState) {
+            fn ser_json(&self, s: &mut SerJsonState) {
                 s.out.push('"');
                 for c in self.chars() {
                     match c {
@@ -874,13 +866,12 @@ impl<T> SerJson for Vec<T>
 where
     T: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push('[');
         if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
-                s.indent(d + 1);
-                item.ser_json(d + 1, s);
+                item.ser_json(s);
                 if index != last {
                     s.out.push(',');
                 }
@@ -912,13 +903,12 @@ impl<T> SerJson for std::collections::HashSet<T>
 where
     T: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push('[');
         if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
-                s.indent(d + 1);
-                item.ser_json(d + 1, s);
+                item.ser_json(s);
                 if index != last {
                     s.out.push(',');
                 }
@@ -950,13 +940,12 @@ impl<T> SerJson for LinkedList<T>
 where
     T: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push('[');
         if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
-                s.indent(d + 1);
-                item.ser_json(d + 1, s);
+                item.ser_json(s);
                 if index != last {
                     s.out.push(',');
                 }
@@ -987,13 +976,12 @@ impl<T> SerJson for BTreeSet<T>
 where
     T: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push('[');
         if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
-                s.indent(d + 1);
-                item.ser_json(d + 1, s);
+                item.ser_json(s);
                 if index != last {
                     s.out.push(',');
                 }
@@ -1024,11 +1012,11 @@ impl<T> SerJson for [T]
 where
     T: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push('[');
         let last = self.len() - 1;
         for (index, item) in self.iter().enumerate() {
-            item.ser_json(d + 1, s);
+            item.ser_json(s);
             if index != last {
                 s.out.push(',');
             }
@@ -1042,8 +1030,8 @@ where
     T: SerJson,
 {
     #[inline(always)]
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
-        self.as_slice().ser_json(d, s)
+    fn ser_json(&self, s: &mut SerJsonState) {
+        self.as_slice().ser_json(s)
     }
 }
 
@@ -1104,11 +1092,11 @@ where
     A: SerJson,
     B: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push('[');
-        self.0.ser_json(d, s);
+        self.0.ser_json(s);
         s.out.push(',');
-        self.1.ser_json(d, s);
+        self.1.ser_json(s);
         s.out.push(']');
     }
 }
@@ -1132,13 +1120,13 @@ where
     B: SerJson,
     C: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push('[');
-        self.0.ser_json(d, s);
+        self.0.ser_json(s);
         s.out.push(',');
-        self.1.ser_json(d, s);
+        self.1.ser_json(s);
         s.out.push(',');
-        self.2.ser_json(d, s);
+        self.2.ser_json(s);
         s.out.push(']');
     }
 }
@@ -1168,15 +1156,15 @@ where
     C: SerJson,
     D: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push('[');
-        self.0.ser_json(d, s);
+        self.0.ser_json(s);
         s.out.push(',');
-        self.1.ser_json(d, s);
+        self.1.ser_json(s);
         s.out.push(',');
-        self.2.ser_json(d, s);
+        self.2.ser_json(s);
         s.out.push(',');
-        self.3.ser_json(d, s);
+        self.3.ser_json(s);
         s.out.push(']');
     }
 }
@@ -1207,19 +1195,17 @@ where
     K: SerJson,
     V: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push('{');
         let len = self.len();
         for (index, (k, v)) in self.iter().enumerate() {
-            s.indent(d + 1);
-            k.ser_json(d + 1, s);
+            k.ser_json(s);
             s.out.push(':');
-            v.ser_json(d + 1, s);
+            v.ser_json(s);
             if (index + 1) < len {
                 s.conl();
             }
         }
-        s.indent(d);
         s.out.push('}');
     }
 }
@@ -1251,19 +1237,17 @@ where
     K: SerJson,
     V: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push('{');
         let len = self.len();
         for (index, (k, v)) in self.iter().enumerate() {
-            s.indent(d + 1);
-            k.ser_json(d + 1, s);
+            k.ser_json(s);
             s.out.push(':');
-            v.ser_json(d + 1, s);
+            v.ser_json(s);
             if (index + 1) < len {
                 s.conl();
             }
         }
-        s.indent(d);
         s.out.push('}');
     }
 }
@@ -1292,8 +1276,8 @@ impl<T> SerJson for Box<T>
 where
     T: SerJson,
 {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
-        (**self).ser_json(d, s)
+    fn ser_json(&self, s: &mut SerJsonState) {
+        (**self).ser_json(s)
     }
 }
 
@@ -1307,7 +1291,7 @@ where
 }
 
 impl SerJson for Duration {
-    fn ser_json(&self, _d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         s.out.push('{');
         _ = write!(s.out, "\"secs\":{}", self.as_secs());
         if self.subsec_nanos() > 0 {
@@ -1362,10 +1346,10 @@ impl DeJson for Duration {
 
 #[cfg(feature = "std")]
 impl SerJson for std::time::SystemTime {
-    fn ser_json(&self, d: usize, s: &mut SerJsonState) {
+    fn ser_json(&self, s: &mut SerJsonState) {
         self.duration_since(std::time::SystemTime::UNIX_EPOCH)
             .ok()
-            .ser_json(d, s);
+            .ser_json(s);
     }
 }
 

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -13,14 +13,7 @@ pub struct SerRonState {
 }
 
 impl SerRonState {
-    pub fn indent(&mut self, _d: usize) {
-        // for _ in 0..d {
-        //     self.out.push_str("    ");
-        // }
-    }
-
-    pub fn field(&mut self, d: usize, field: &str) {
-        self.indent(d);
+    pub fn field(&mut self, field: &str) {
         self.out.push_str(field);
         self.out.push(':');
     }
@@ -33,8 +26,7 @@ impl SerRonState {
         self.out.push('(');
     }
 
-    pub fn st_post(&mut self, d: usize) {
-        self.indent(d);
+    pub fn st_post(&mut self) {
         self.out.push(')');
     }
 }
@@ -48,7 +40,7 @@ pub trait SerRon {
     /// This is a convenient wrapper around `ser_ron`.
     fn serialize_ron(&self) -> String {
         let mut s = SerRonState { out: String::new() };
-        self.ser_ron(0, &mut s);
+        self.ser_ron(&mut s);
         s.out
     }
 
@@ -57,10 +49,10 @@ pub trait SerRon {
     /// ```rust
     /// # use nanoserde::*;
     /// let mut s = SerRonState { out: String::new() };
-    /// 42u32.ser_ron(0, &mut s);
+    /// 42u32.ser_ron(&mut s);
     /// assert_eq!(s.out, "42");
     /// ```
-    fn ser_ron(&self, indent_level: usize, state: &mut SerRonState);
+    fn ser_ron(&self, state: &mut SerRonState);
 }
 
 /// A trait for objects that can be deserialized from the RON file format.
@@ -709,7 +701,7 @@ impl DeRonState {
 macro_rules! impl_ser_de_ron_unsigned {
     ( $ ty: ident, $ max: expr) => {
         impl SerRon for $ty {
-            fn ser_ron(&self, _d: usize, s: &mut SerRonState) {
+            fn ser_ron(&self, s: &mut SerRonState) {
                 _ = write!(s.out, "{self}");
             }
         }
@@ -728,7 +720,7 @@ macro_rules! impl_ser_de_ron_unsigned {
 macro_rules! impl_ser_de_ron_signed {
     ( $ ty: ident, $ min: expr, $ max: expr) => {
         impl SerRon for $ty {
-            fn ser_ron(&self, _d: usize, s: &mut SerRonState) {
+            fn ser_ron(&self, s: &mut SerRonState) {
                 _ = write!(s.out, "{self}");
             }
         }
@@ -747,7 +739,7 @@ macro_rules! impl_ser_de_ron_signed {
 macro_rules! impl_ser_de_ron_float {
     ( $ ty: ident) => {
         impl SerRon for $ty {
-            fn ser_ron(&self, _d: usize, s: &mut SerRonState) {
+            fn ser_ron(&self, s: &mut SerRonState) {
                 _ = write!(s.out, "{self:?}");
             }
         }
@@ -779,9 +771,9 @@ impl<T> SerRon for Option<T>
 where
     T: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         if let Some(v) = self {
-            v.ser_ron(d, s);
+            v.ser_ron(s);
         } else {
             s.out.push_str("None");
         }
@@ -804,7 +796,7 @@ where
 }
 
 impl SerRon for bool {
-    fn ser_ron(&self, _d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         if *self {
             s.out.push_str("true")
         } else {
@@ -822,7 +814,7 @@ impl DeRon for bool {
 }
 
 impl SerRon for String {
-    fn ser_ron(&self, _d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('"');
         for c in self.chars() {
             match c {
@@ -869,14 +861,12 @@ impl<T> SerRon for Vec<T>
 where
     T: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('[');
         for item in self {
-            s.indent(d + 1);
-            item.ser_ron(d + 1, s);
+            item.ser_ron(s);
             s.conl();
         }
-        s.indent(d);
         s.out.push(']');
     }
 }
@@ -903,13 +893,12 @@ impl<T> SerRon for std::collections::HashSet<T>
 where
     T: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('[');
         if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
-                s.indent(d + 1);
-                item.ser_ron(d + 1, s);
+                item.ser_ron(s);
                 if index != last {
                     s.out.push(',');
                 }
@@ -941,13 +930,12 @@ impl<T> SerRon for LinkedList<T>
 where
     T: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('[');
         if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
-                s.indent(d + 1);
-                item.ser_ron(d + 1, s);
+                item.ser_ron(s);
                 if index != last {
                     s.out.push(',');
                 }
@@ -978,13 +966,12 @@ impl<T> SerRon for BTreeSet<T>
 where
     T: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('[');
         if !self.is_empty() {
             let last = self.len() - 1;
             for (index, item) in self.iter().enumerate() {
-                s.indent(d + 1);
-                item.ser_ron(d + 1, s);
+                item.ser_ron(s);
                 if index != last {
                     s.out.push(',');
                 }
@@ -1015,11 +1002,11 @@ impl<T> SerRon for [T]
 where
     T: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('(');
         let last = self.len() - 1;
         for (index, item) in self.iter().enumerate() {
-            item.ser_ron(d + 1, s);
+            item.ser_ron(s);
             if index != last {
                 s.out.push(',');
             }
@@ -1033,8 +1020,8 @@ where
     T: SerRon,
 {
     #[inline(always)]
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
-        self.as_slice().ser_ron(d, s)
+    fn ser_ron(&self, s: &mut SerRonState) {
+        self.as_slice().ser_ron(s)
     }
 }
 
@@ -1091,7 +1078,7 @@ where
 }
 
 impl SerRon for () {
-    fn ser_ron(&self, _d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push_str("()");
     }
 }
@@ -1109,11 +1096,11 @@ where
     A: SerRon,
     B: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('(');
-        self.0.ser_ron(d, s);
+        self.0.ser_ron(s);
         s.out.push(',');
-        self.1.ser_ron(d, s);
+        self.1.ser_ron(s);
         s.out.push(')');
     }
 }
@@ -1137,13 +1124,13 @@ where
     B: SerRon,
     C: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('(');
-        self.0.ser_ron(d, s);
+        self.0.ser_ron(s);
         s.out.push(',');
-        self.1.ser_ron(d, s);
+        self.1.ser_ron(s);
         s.out.push(',');
-        self.2.ser_ron(d, s);
+        self.2.ser_ron(s);
         s.out.push(')');
     }
 }
@@ -1173,15 +1160,15 @@ where
     C: SerRon,
     D: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('(');
-        self.0.ser_ron(d, s);
+        self.0.ser_ron(s);
         s.out.push(',');
-        self.1.ser_ron(d, s);
+        self.1.ser_ron(s);
         s.out.push(',');
-        self.2.ser_ron(d, s);
+        self.2.ser_ron(s);
         s.out.push(',');
-        self.3.ser_ron(d, s);
+        self.3.ser_ron(s);
         s.out.push(')');
     }
 }
@@ -1212,16 +1199,14 @@ where
     K: SerRon,
     V: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('{');
         for (k, v) in self {
-            s.indent(d + 1);
-            k.ser_ron(d + 1, s);
+            k.ser_ron(s);
             s.out.push(':');
-            v.ser_ron(d + 1, s);
+            v.ser_ron(s);
             s.conl();
         }
-        s.indent(d);
         s.out.push('}');
     }
 }
@@ -1252,16 +1237,14 @@ where
     K: SerRon,
     V: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('{');
         for (k, v) in self {
-            s.indent(d + 1);
-            k.ser_ron(d + 1, s);
+            k.ser_ron(s);
             s.out.push(':');
-            v.ser_ron(d + 1, s);
+            v.ser_ron(s);
             s.conl();
         }
-        s.indent(d);
         s.out.push('}');
     }
 }
@@ -1290,8 +1273,8 @@ impl<T> SerRon for Box<T>
 where
     T: SerRon,
 {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
-        (**self).ser_ron(d, s)
+    fn ser_ron(&self, s: &mut SerRonState) {
+        (**self).ser_ron(s)
     }
 }
 
@@ -1305,7 +1288,7 @@ where
 }
 
 impl SerRon for Duration {
-    fn ser_ron(&self, _d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         s.out.push('{');
         _ = write!(s.out, "\"secs\":{}", self.as_secs());
         if self.subsec_nanos() > 0 {
@@ -1360,10 +1343,10 @@ impl DeRon for Duration {
 
 #[cfg(feature = "std")]
 impl SerRon for std::time::SystemTime {
-    fn ser_ron(&self, d: usize, s: &mut SerRonState) {
+    fn ser_ron(&self, s: &mut SerRonState) {
         self.duration_since(std::time::SystemTime::UNIX_EPOCH)
             .ok()
-            .ser_ron(d, s);
+            .ser_ron(s);
     }
 }
 


### PR DESCRIPTION
Also adds support for json serialization and deserialization of Arc<str> and Rc<str>.