### PR TITLE
fix(ron): round-trip non-finite floats (inf/-inf/NaN)

### DIFF
--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -411,6 +411,17 @@ impl DeRonState {
         if let DeRonTok::F64(value) = self.tok {
             return Ok(value);
         }
+        // The non-finite float literals `inf` and `NaN` (RON also accepts
+        // `-inf`/`+inf`, which are tokenized as `F64` above) are scanned as
+        // bare identifiers, so accept them here when a float is expected.
+        if let DeRonTok::Ident = self.tok {
+            if self.identbuf == "inf" {
+                return Ok(f64::INFINITY);
+            }
+            if self.identbuf == "NaN" {
+                return Ok(f64::NAN);
+            }
+        }
         Err(self.err_token("floating point"))
     }
 
@@ -519,6 +530,25 @@ impl DeRonState {
                     } else {
                         false
                     };
+                    // A sign followed by `inf` is the non-finite float literal
+                    // `-inf`/`+inf` (as emitted by `SerRon` for infinities).
+                    if self.cur == 'i' {
+                        self.identbuf.truncate(0);
+                        while self.cur >= 'a' && self.cur <= 'z' {
+                            self.identbuf.push(self.cur);
+                            self.next(i);
+                        }
+                        if self.identbuf == "inf" {
+                            self.tok = DeRonTok::F64(if is_neg {
+                                f64::NEG_INFINITY
+                            } else {
+                                f64::INFINITY
+                            });
+                            return Ok(());
+                        } else {
+                            return Err(self.err_parse("number"));
+                        }
+                    }
                     while self.cur >= '0' && self.cur <= '9' {
                         self.numbuf.push(self.cur);
                         self.next(i);

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -813,3 +813,74 @@ fn std_time() {
     let deserialized_none: SystemTime = DeRon::deserialize_ron(none).unwrap();
     assert_eq!(deserialized_none, SystemTime::UNIX_EPOCH);
 }
+
+#[test]
+fn ron_de_ser_non_finite_floats() {
+    // `SerRon` emits `NaN`, `inf` and `-inf` for non-finite floats (matching
+    // the RON specification and the reference `ron` crate), so the RON
+    // deserializer must round-trip them back. Previously these tokens failed
+    // to parse, making `deserialize_ron(serialize_ron(x))` error for any value
+    // containing an infinity or NaN.
+
+    // f64
+    assert!(f64::deserialize_ron(&f64::INFINITY.serialize_ron())
+        .unwrap()
+        .is_infinite());
+    assert_eq!(
+        f64::deserialize_ron(&f64::INFINITY.serialize_ron()).unwrap(),
+        f64::INFINITY
+    );
+    assert_eq!(
+        f64::deserialize_ron(&f64::NEG_INFINITY.serialize_ron()).unwrap(),
+        f64::NEG_INFINITY
+    );
+    assert!(f64::deserialize_ron(&f64::NAN.serialize_ron())
+        .unwrap()
+        .is_nan());
+
+    // f32
+    assert_eq!(
+        f32::deserialize_ron(&f32::INFINITY.serialize_ron()).unwrap(),
+        f32::INFINITY
+    );
+    assert_eq!(
+        f32::deserialize_ron(&f32::NEG_INFINITY.serialize_ron()).unwrap(),
+        f32::NEG_INFINITY
+    );
+    assert!(f32::deserialize_ron(&f32::NAN.serialize_ron())
+        .unwrap()
+        .is_nan());
+
+    // Parse the literal forms directly (as accepted by the RON spec).
+    assert_eq!(f64::deserialize_ron("inf").unwrap(), f64::INFINITY);
+    assert_eq!(f64::deserialize_ron("+inf").unwrap(), f64::INFINITY);
+    assert_eq!(f64::deserialize_ron("-inf").unwrap(), f64::NEG_INFINITY);
+    assert!(f64::deserialize_ron("NaN").unwrap().is_nan());
+
+    // Non-finite floats nested inside a struct must round-trip too.
+    #[derive(DeRon, SerRon, Debug)]
+    struct Holder {
+        a: f32,
+        b: f64,
+        c: Vec<f64>,
+        d: Option<f32>,
+    }
+    let h = Holder {
+        a: f32::NEG_INFINITY,
+        b: f64::INFINITY,
+        c: vec![f64::NAN, 1.5, f64::NEG_INFINITY],
+        d: Some(f32::NAN),
+    };
+    let back: Holder = DeRon::deserialize_ron(&h.serialize_ron()).unwrap();
+    assert_eq!(back.a, f32::NEG_INFINITY);
+    assert_eq!(back.b, f64::INFINITY);
+    assert!(back.c[0].is_nan());
+    assert_eq!(back.c[1], 1.5);
+    assert_eq!(back.c[2], f64::NEG_INFINITY);
+    assert!(back.d.unwrap().is_nan());
+
+    // Finite floats must keep working (no regression).
+    assert_eq!(f64::deserialize_ron("-1.5").unwrap(), -1.5);
+    assert_eq!(f64::deserialize_ron("2.0").unwrap(), 2.0);
+    assert_eq!(i64::deserialize_ron("-42").unwrap(), -42);
+}


### PR DESCRIPTION
`SerRon` serializes non-finite floats as `inf`, `-inf` and `NaN` (matching the RON specification and the reference `ron` crate), but the RON deserializer rejected all of these tokens. As a result `deserialize_ron(serialize_ron(x))` returned an error for any `f32`/`f64` that was infinite or NaN, including values nested inside a struct/`Vec`/`Option`.

Before:
```
f64  inf: ron="inf"  -> RON DE ERR: Unexpected token Ident expected floating point
f64 -inf: ron="-inf" -> RON DE ERR: Cannot parse number
f64  NaN: ron="NaN"  -> RON DE ERR: Unexpected token Ident expected floating point
```

Bare `inf`/`NaN` are scanned as identifiers, so they're now accepted in `as_f64` when a float is expected; `-inf`/`+inf` reach the number branch after the sign, so the `inf` literal is parsed there. Serialization is unchanged. Adds a regression test covering scalars, the literal forms (`inf`/`+inf`/`-inf`/`NaN`), and non-finite floats nested in a struct. (The sibling TOML module already handles these tokens; RON was simply missed.)
