### PR TITLE
fix(json,ron): accept a leading + in float exponents

### DIFF
--- a/src/serde_json.rs
+++ b/src/serde_json.rs
@@ -545,7 +545,7 @@ impl DeJsonState {
                     is_float = true;
                     self.numbuf.push(self.cur);
                     self.next(i);
-                    if self.cur == '-' {
+                    if self.cur == '-' || self.cur == '+' {
                         self.numbuf.push(self.cur);
                         self.next(i);
                     }

--- a/src/serde_ron.rs
+++ b/src/serde_ron.rs
@@ -567,7 +567,7 @@ impl DeRonState {
                         is_float = true;
                         self.numbuf.push(self.cur);
                         self.next(i);
-                        if self.cur == '-' {
+                        if self.cur == '-' || self.cur == '+' {
                             self.numbuf.push(self.cur);
                             self.next(i);
                         }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -649,6 +649,34 @@ fn exponents() {
 }
 
 #[test]
+fn exponents_with_plus_sign() {
+    #[derive(DeJson)]
+    struct Foo {
+        a: f64,
+        b: f64,
+        c: f64,
+        d: f64,
+        e: f64,
+    }
+
+    let json = r#"{
+        "a": 1e+2,
+        "b": 1E+2,
+        "c": 1.0e+2,
+        "d": 1.0E+2,
+        "e": -1.5e+3
+    }"#;
+
+    let foo: Foo = DeJson::deserialize_json(json).unwrap();
+
+    assert_eq!(foo.a, 100.);
+    assert_eq!(foo.b, 100.);
+    assert_eq!(foo.c, 100.);
+    assert_eq!(foo.d, 100.);
+    assert_eq!(foo.e, -1500.);
+}
+
+#[test]
 fn collections() {
     #[derive(DeJson, SerJson, PartialEq, Debug)]
     pub struct Test {

--- a/tests/ron.rs
+++ b/tests/ron.rs
@@ -377,6 +377,34 @@ fn exponents() {
 }
 
 #[test]
+fn exponents_with_plus_sign() {
+    #[derive(DeRon)]
+    struct Foo {
+        a: f64,
+        b: f64,
+        c: f64,
+        d: f64,
+        e: f64,
+    }
+
+    let ron = r#"(
+        a: 1e+2,
+        b: 1E+2,
+        c: 1.0e+2,
+        d: 1.0E+2,
+        e: -1.5e+3
+    )"#;
+
+    let foo: Foo = DeRon::deserialize_ron(ron).unwrap();
+
+    assert_eq!(foo.a, 100.);
+    assert_eq!(foo.b, 100.);
+    assert_eq!(foo.c, 100.);
+    assert_eq!(foo.d, 100.);
+    assert_eq!(foo.e, -1500.);
+}
+
+#[test]
 fn ronerror() {
     #[derive(DeRon)]
     #[allow(dead_code)]


### PR DESCRIPTION
`1e+5` is valid JSON (RFC 8259: `exp = ("e" / "E") ["-" / "+"] 1*DIGIT`) and valid RON, but nanoserde rejects it with "Cannot parse number".

The exponent branch of the tokenizer only consumes a `-`, so for `1e+5` the `+` is never read, `numbuf` ends up as `"1e"`, and the parse fails. Same code, same bug, in both `serde_json.rs` and `serde_ron.rs`.

```rust
f64::deserialize_json("1e+5")
// Err(Json Deserialize error: Cannot parse number , line:1 col:4)
// serde_json gives Ok(100000.0)
```

This bites on real input since plenty of encoders emit `e+` (printf `%g`, JS `Number.toString` for >=1e21, Python `repr`). nanoserde's own output never uses it, so round-trip tests never caught it.

Found it with a differential harness against `serde_json`: 40000 randomized numbers, 13445 disagreements, every one of them the `+` exponent. After the fix, 0. The only remaining differences were serde_json's fast-path float being 1 ULP off on things like `-767e-23`, where nanoserde matches the correctly-rounded value, so nothing to do there.

I extended the existing `exponents` tests in `tests/json.rs` and `tests/ron.rs` with the `+` forms. They fail on master and pass with the fix. Full suite plus the no_std/feature-gated combos from CI are green.

TOML rejects exponents entirely, both `e+` and `e-`, which looks like a separate gap. Left it alone.

AI assistance disclosure: I used an AI assistant to help run the differential harness and draft this. I reviewed and verified the change and the test results myself.
