### PR TITLE
Harden DeBin against untrusted length prefixes (CWE-770 unbounded allocation, plus String overflow panic)

### DIFF
--- a/src/serde_bin.rs
+++ b/src/serde_bin.rs
@@ -254,16 +254,21 @@ impl SerBin for String {
 impl DeBin for String {
     fn de_bin(o: &mut usize, d: &[u8]) -> Result<String, DeBinErr> {
         let len: usize = DeBin::de_bin(o, d)?;
-        if *o + len > d.len() {
-            return Err(DeBinErr {
-                o: *o,
-                msg: DeBinErrReason::Length {
-                    expected_length: 1,
-                    actual_length: d.len(),
-                },
-            });
-        }
-        let r = match core::str::from_utf8(&d[*o..(*o + len)]) {
+        // Use checked arithmetic: `*o + len` could overflow and bypass this check
+        // (e.g. *o = 1, len = usize::MAX), panicking on the slice below.
+        let end = match (*o).checked_add(len) {
+            Some(end) if end <= d.len() => end,
+            _ => {
+                return Err(DeBinErr {
+                    o: *o,
+                    msg: DeBinErrReason::Length {
+                        expected_length: len,
+                        actual_length: d.len(),
+                    },
+                });
+            }
+        };
+        let r = match core::str::from_utf8(&d[*o..end]) {
             Ok(r) => r.to_owned(),
             Err(_) => {
                 return Err(DeBinErr {
@@ -299,7 +304,11 @@ where
 {
     fn de_bin(o: &mut usize, d: &[u8]) -> Result<Vec<T>, DeBinErr> {
         let len: usize = DeBin::de_bin(o, d)?;
-        let mut out = Vec::with_capacity(len);
+        // Do not reserve capacity based on the untrusted declared length: a small
+        // malformed buffer could otherwise trigger an allocation of len * size_of::<T>()
+        // (up to ~2^64 elements) before any element is successfully read.
+        // Grow from actual data instead, mirroring LinkedList/BTreeSet/BTreeMap below.
+        let mut out = Vec::new();
         for _ in 0..len {
             out.push(DeBin::de_bin(o, d)?)
         }
@@ -355,7 +364,8 @@ where
 {
     fn de_bin(o: &mut usize, d: &[u8]) -> Result<Self, DeBinErr> {
         let len: usize = DeBin::de_bin(o, d)?;
-        let mut out = std::collections::HashSet::with_capacity(len);
+        // Do not reserve capacity based on the untrusted declared length (see Vec impl).
+        let mut out = std::collections::HashSet::new();
         for _ in 0..len {
             out.insert(DeBin::de_bin(o, d)?);
         }
@@ -602,7 +612,8 @@ where
 {
     fn de_bin(o: &mut usize, d: &[u8]) -> Result<Self, DeBinErr> {
         let len: usize = DeBin::de_bin(o, d)?;
-        let mut h = std::collections::HashMap::with_capacity(len);
+        // Do not reserve capacity based on the untrusted declared length (see Vec impl).
+        let mut h = std::collections::HashMap::new();
         for _ in 0..len {
             let k = DeBin::de_bin(o, d)?;
             let v = DeBin::de_bin(o, d)?;

--- a/tests/untrusted_alloc.rs
+++ b/tests/untrusted_alloc.rs
@@ -1,0 +1,86 @@
+//! Regression tests: untrusted length prefixes in DeBin must not drive
+//! large allocations (CWE-770) or panic via integer overflow (CWE-680).
+//!
+//! The counting `#[global_allocator]` is process-global, so all checks are
+//! merged into a single `#[test]` to keep them serial and unpolluted.
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+static CURRENT: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            CURRENT.fetch_add(layout.size(), Ordering::SeqCst);
+            PEAK.fetch_max(CURRENT.load(Ordering::SeqCst), Ordering::SeqCst);
+        }
+        ptr
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        CURRENT.fetch_sub(layout.size(), Ordering::SeqCst);
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = System.realloc(ptr, layout, new_size);
+        if !new_ptr.is_null() {
+            CURRENT.fetch_sub(layout.size(), Ordering::SeqCst);
+            CURRENT.fetch_add(new_size, Ordering::SeqCst);
+            PEAK.fetch_max(CURRENT.load(Ordering::SeqCst), Ordering::SeqCst);
+        }
+        new_ptr
+    }
+}
+
+#[global_allocator]
+static A: Counting = Counting;
+
+use nanoserde::DeBin;
+
+/// An 8-byte declared length (64 MiB) with no element data must error without
+/// preallocating 64 MiB in Vec / HashSet / HashMap, and an overflowing String
+/// length must return Err instead of panicking.
+#[test]
+fn untrusted_length_prefix_is_bounded() {
+    let declared: u64 = 64 * 1024 * 1024;
+    let data = declared.to_le_bytes().to_vec(); // 8 bytes, truncated
+
+    // Vec<u8>
+    PEAK.store(0, Ordering::SeqCst);
+    assert!(Vec::<u8>::de_bin(&mut 0, &data).is_err());
+    let vec_peak = PEAK.load(Ordering::SeqCst);
+    assert!(
+        vec_peak < 8192,
+        "Vec must grow from actual data, not from the declared length (peak {vec_peak} bytes)"
+    );
+
+    // HashMap<u8, u8>
+    PEAK.store(0, Ordering::SeqCst);
+    assert!(std::collections::HashMap::<u8, u8>::de_bin(&mut 0, &data).is_err());
+    let map_peak = PEAK.load(Ordering::SeqCst);
+    assert!(
+        map_peak < 8192,
+        "HashMap must grow from actual data, not from the declared length (peak {map_peak} bytes)"
+    );
+
+    // HashSet<u8>
+    PEAK.store(0, Ordering::SeqCst);
+    assert!(std::collections::HashSet::<u8>::de_bin(&mut 0, &data).is_err());
+    let set_peak = PEAK.load(Ordering::SeqCst);
+    assert!(
+        set_peak < 8192,
+        "HashSet must grow from actual data, not from the declared length (peak {set_peak} bytes)"
+    );
+
+    // String: `*o + len` used to overflow (o=1, len=usize::MAX) and panic on the slice.
+    let mut data = vec![0xAAu8];
+    data.extend((usize::MAX as u64).to_le_bytes());
+    let r = std::panic::catch_unwind(|| String::de_bin(&mut 1, &data));
+    assert!(
+        matches!(r, Ok(Err(_))),
+        "overflowing String length must return Err, not panic"
+    );
+}


### PR DESCRIPTION
# Harden `DeBin` deserialization against untrusted length prefixes (CWE-770 unbounded allocation + overflow panic)

## Summary

`DeBin` (the binary format deserializer) reads a length prefix from the input and, for `Vec<T>`, `HashSet<T>` and `HashMap<K, V>`, uses it to **preallocate capacity before a single element is read**. A malformed 8-byte input can therefore force allocations of gigabytes — or abort the process outright — while contributing essentially no data. This PR also fixes an integer overflow in `String`'s bounds check that turns a `usize::MAX` length into a panic.

## Details

Lengths are deserialized via `DeBin for usize`, which reads an **8-byte LE `u64`** from the untrusted buffer. For collections:

```rust
// before (src/serde_bin.rs, DeBin for Vec<T>)
let len: usize = DeBin::de_bin(o, d)?;      // attacker-controlled, up to 2^64-1
let mut out = Vec::with_capacity(len);      // allocates len * size_of::<T>() up front
for _ in 0..len {
    out.push(DeBin::de_bin(o, d)?)          // truncation is only detected here,
}                                            // after the allocation already happened
```

The same unchecked pattern exists in `HashSet::with_capacity(len)` and `HashMap::with_capacity(len)`. By contrast, the `LinkedList`, `BTreeSet` and `BTreeMap` impls in the same file already use `::new()` and grow from actual data, and `String` bounds-checks the declared length — so this looks like an oversight in exactly the three impls that preallocate.

**The overflow.** `String`'s check `*o + len > d.len()` can itself overflow on 64-bit targets (e.g. `*o = 1`, `len = usize::MAX` → the sum wraps to `8`), after which `&d[*o..(*o + len)]` panics with "slice index starts at 9 but ends at 8". In release builds without overflow checks this is a reachable panic on malformed input.

## Impact

Deserializing untrusted binary data is a normal use case for `DeBin` (network peers, user-supplied save files / documents, IPC payloads). With a counting global allocator, an 8-byte truncated buffer:

| impl | before | after |
|---|---|---|
| `Vec<u8>` (declares 64 MiB) | **67,108,864-byte single allocation** | 124 bytes, then `Err` |
| `HashMap<u8, u8>` (declares 64 MiB entries) | **402,657,123-byte single allocation** | 544 bytes, then `Err` |
| `HashSet<u8>` (declares 64 MiB entries) | **268,439,403-byte single allocation** | 544 bytes, then `Err` |
| `String` (declares `usize::MAX` at offset 1) | **panic** (slice index) | `Err` |

Amplification is bounded only by `u64::MAX * size_of::<T>()`. Declaring more than physical memory aborts the process in `handle_alloc_error` — verified: an 8-byte input declaring 1 TiB for `Vec<u8>` exits with `0xC0000409` (Windows abort); `catch_unwind` cannot intercept it. A service deserializing peer-supplied payloads can be killed by a single small message.

## Fix

No API change, no magic-number caps: the three collection impls now grow from the data actually present (`::new()` + push/insert), consistent with the existing `LinkedList` / `BTreeSet` / `BTreeMap` impls, and `String` uses `checked_add` for the end offset. Valid inputs produce identical results; only the preallocation is gone (a few geometric re-growths for large legitimate vectors).

## Testing

New `tests/untrusted_alloc.rs` uses a counting `#[global_allocator]` to assert that peak allocation stays proportional to the actual input (< 8 KiB) and that the overflow case returns `Err` instead of panicking. All checks run in a single `#[test]` because the global allocator is process-global and parallel tests would pollute the counters. Verified bidirectionally: with the fix stashed, the test fails (`peak 67,112,831 bytes`); with the fix applied, the full `cargo test --lib --tests` suite passes.

Happy to adjust if you would prefer a bounded `try_reserve` instead of pure incremental growth.

Reporter: Li Jinquan — github.com/li-jin-quan
